### PR TITLE
Fixed mat4_set_frustum clipping issue.

### DIFF
--- a/mat4.c
+++ b/mat4.c
@@ -161,14 +161,14 @@ mat4_set_frustum( mat4 *self,
 
     mat4_set_zero( self );
 
-    self->m00 = +2.0*znear/(right-left);
+    self->m00 = (2.0*znear)/(right-left);
     self->m20 = (right+left)/(right-left);
 
-    self->m11 = +2.0*znear/(top-bottom);
-    self->m31 = (top+bottom)/(top-bottom);
+    self->m11 = (2.0*znear)/(top-bottom);
+    self->m21 = (top+bottom)/(top-bottom);
 
     self->m22 = -(zfar+znear)/(zfar-znear);
-    self->m32 = -2.0*znear/(zfar-znear);
+    self->m32 = -(2.0*zfar*znear)/(zfar-znear);
 
     self->m23 = -1.0;
 }


### PR DESCRIPTION
Noticed mat4_set_frustum and mat4_set_perspective were not working as expected. Notably, they were not setting the far clipping plane. I have updated mat4_set_frustum to match the man pages (http://www.manpagez.com/man/3/glFrustum/). In particular ->m31 should be ->m21 and ->m32 was missing the zfar term.
