### PR TITLE
Allow required libs to be supplied by parent build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ SET( CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules"
                        "${CMAKE_MODULE_PATH}" )
 
 OPTION(freetype-gl_BUILD_DEMOS "Build the freetype-gl example programs" ON)
+OPTION(freetype-gl_LIBS_SUPPLIED "Required libraries are supplied as part of parent build" OFF)
 
 # Get required and optional library
 FIND_PACKAGE( OpenGL REQUIRED )
@@ -65,9 +66,16 @@ IF( WIN32 OR WIN64 )
          ${CMAKE_CURRENT_SOURCE_DIR}/windows/include )
     SET( ANT_TWEAK_BAR_FOUND "YES" )
 ELSE( WIN32 OR WIN64 )
-    FIND_PACKAGE( GLUT REQUIRED )
-    FIND_PACKAGE( Freetype REQUIRED )
-    FIND_PACKAGE( GLEW REQUIRED )
+    IF ( freetype-gl_LIBS_SUPPLIED )
+        FIND_PACKAGE( GLUT )
+        FIND_PACKAGE( Freetype )
+        FIND_PACKAGE( GLEW )
+    ELSE ( freetype-gl_LIBS_SUPPLIED )
+        FIND_PACKAGE( GLUT REQUIRED )
+        FIND_PACKAGE( Freetype REQUIRED )
+        FIND_PACKAGE( GLEW REQUIRED )
+    ENDIF ( freetype-gl_LIBS_SUPPLIED )
+
     FIND_PACKAGE( FontConfig )
     FIND_LIBRARY( MATH_LIBRARY m )
     #FIND_LIBRARY( STDC_LIBRARY stdc++) #Buggy Cmake can't find libstdc++


### PR DESCRIPTION
I'm building freetype-gl as part of a parent CMake project. This project also builds freetype and glew, whose headers and built libraries are therefore available when freetype-gl is built, removing the need for the required option in the FIND_PACKAGE commands.

My proposal is to allow the user of freetype-gl to choose whether the libraries are required on the system, or will be passed in as part of a parent build. The default will of course remain as is currently.

Here is a snippet from my CMakeLists.txt demonstrating the change:

```cmake
# glew
OPTION(glew-cmake_BUILD_SHARED "Build the shared glew library" OFF)
ADD_SUBDIRECTORY(lib/glew)

SET(GLEW_INCLUDE_PATH "${MAINFOLDER}/lib/glew/include")

# freetype2
ADD_SUBDIRECTORY(lib/freetype2)
SET(FREETYPE_INCLUDE_DIRS "${MAINFOLDER}/lib/freetype2/include")

# freetype-gl
OPTION(freetype-gl_BUILD_DEMOS "Build the freetype-gl example programs" OFF)
OPTION(freetype-gl_LIBS_SUPPLIED "Required libraries are supplied as part of parent build" ON)

ADD_SUBDIRECTORY(lib/freetype-gl)
SET(LIB_FREETYPE_GL_INCLUDE_PATH "${MAINFOLDER}/lib/freetype-gl")
```