### PR TITLE
Updated text-buffer to allow for custom shaders.

### DIFF
--- a/text-buffer.c
+++ b/text-buffer.c
@@ -52,13 +52,25 @@
 text_buffer_t *
 text_buffer_new( size_t depth )
 {
+    return text_buffer_new_with_shaders(depth, 
+                                        "shaders/text.vert",
+                                        "shaders/text.frag");
+}
+
+// ----------------------------------------------------------------------------
+
+text_buffer_t *
+text_buffer_new_with_shaders( size_t depth,
+                              const char * vert_filename,
+                              const char * frag_filename )
+{
     
     text_buffer_t *self = (text_buffer_t *) malloc (sizeof(text_buffer_t));
     self->buffer = vertex_buffer_new(
-        "vertex:3f,tex_coord:2f,color:4f,ashift:1f,agamma:1f" );
+                                     "vertex:3f,tex_coord:2f,color:4f,ashift:1f,agamma:1f" );
     self->manager = font_manager_new( 512, 512, depth );
-    self->shader = shader_load("shaders/text.vert",
-                               "shaders/text.frag");
+    self->shader = shader_load(vert_filename,
+                               frag_filename);
     self->shader_texture = glGetUniformLocation(self->shader, "texture");
     self->shader_pixel = glGetUniformLocation(self->shader, "pixel");
     self->line_start = 0;

--- a/text-buffer.h
+++ b/text-buffer.h
@@ -211,6 +211,23 @@ typedef struct glyph_vertex_t {
   text_buffer_t *
   text_buffer_new( size_t depth );
 
+
+
+/**
+ * Creates a new empty text buffer using custom shaders.
+ *
+ * @param depth          Underlying atlas bit depth (1 or 3)
+ * @param vert_filename  Path to vertex shader
+ * @param frag_filename  Path to fragment shader
+ *
+ * @return  a new empty text buffer.
+ *
+ */
+  text_buffer_t *
+  text_buffer_new_with_shaders( size_t depth,
+                                const char * vert_filename,
+                                const char * frag_filename );
+
   /**
   * Deletes texture buffer and its associated shader and vertex buffer.
   *


### PR DESCRIPTION
I'm working on an OSX app and I'd like to be able to bundle the text_buffer vert/frag shaders in the app itself. Since the shader paths are currently hardcoded in text-buffer.c I implemented a second new method that allows for custom shader paths to be passed.

	* added text_buffer_new_with_shaders() function
	* call text_buffer_new_with_shaders() from text_buffer_new() using original text shader paths