### PR TITLE
Updated vertex-buffer.c, fixed incorrect assert in vertex_buffer_erase_vertices()

### DIFF
--- a/vertex-buffer.c
+++ b/vertex-buffer.c
@@ -561,7 +561,7 @@ vertex_buffer_erase_vertices( vertex_buffer_t *self,
     assert( self );
     assert( self->vertices );
     assert( first < self->vertices->size );
-    assert( (first+last) <= self->vertices->size );
+    assert( last < self->vertices->size );
     assert( last > first );
 
     self->state |= DIRTY;

--- a/vertex-buffer.c
+++ b/vertex-buffer.c
@@ -561,7 +561,7 @@ vertex_buffer_erase_vertices( vertex_buffer_t *self,
     assert( self );
     assert( self->vertices );
     assert( first < self->vertices->size );
-    assert( last < self->vertices->size );
+    assert( last <= self->vertices->size );
     assert( last > first );
 
     self->state |= DIRTY;


### PR DESCRIPTION
I moved on to using vertex_buffer in my app to dynamically add/remove characters and was getting a crash when calling vertex_buffer_erase(). This was due to an incorrect assert in vertex_buffer_erase_vertices(). The assert was assuming that 'last' was a length and doing (first+last) <= size. 'last' is an already calculated index and thus the assert should actually be last < size.

I've made this change and can confirm that vertex_buffer_erase_vertices() (and by extension vertex_buffer_erase()) now works as expected.