### PR TITLE
Restore OpenGL state, higher resolution embedded fonts, and externally linked GLSL program

### DIFF
--- a/makefont.c
+++ b/makefont.c
@@ -65,7 +65,7 @@ void keyboard( unsigned char key, int x, int y )
 void print_help()
 {
     fprintf( stderr, "Usage: makefont [--help] --font <font file> "
-             "--header <header file> --size <font size> --variable <variable name>\n" );
+             "--header <header file> --size <font size> --variable <variable name> --texture <texture size>\n" );
 }
 
 // ------------------------------------------------------------------- main ---
@@ -85,6 +85,7 @@ int main( int argc, char **argv )
     const char * header_filename = NULL;
     const char * variable_name   = "font";
     int show_help = 0;
+    size_t texture_width = 128;
 
     for ( arg = 1; arg < argc; ++arg )
     {
@@ -192,6 +193,38 @@ int main( int argc, char **argv )
             continue;
         }
 
+        if ( 0 == strcmp( "--texture", argv[arg] ) || 0 == strcmp( "-t", argv[arg] ) )
+        {
+            ++arg;
+
+            if ( 128.0 != texture_width )
+            {
+                fprintf( stderr, "Multiple --texture parameters.\n" );
+                print_help();
+                exit( 1 );
+            }
+
+            if ( arg >= argc )
+            {
+                fprintf( stderr, "No texture size given.\n" );
+                print_help();
+                exit( 1 );
+            }
+
+            errno = 0;
+
+            texture_width = atof( argv[arg] );
+
+            if ( errno )
+            {
+                fprintf( stderr, "No valid texture size given.\n" );
+                print_help();
+                exit( 1 );
+            }
+
+            continue;
+        }
+
         fprintf( stderr, "Unknown parameter %s\n", argv[arg] );
         print_help();
         exit( 1 );
@@ -231,7 +264,7 @@ int main( int argc, char **argv )
         exit( 1 );
     }
 
-    texture_atlas_t * atlas = texture_atlas_new( 128, 128, 1 );
+    texture_atlas_t * atlas = texture_atlas_new( texture_width, texture_width, 1 );
     texture_font_t  * font  = texture_font_new_from_file( atlas, font_size, font_filename );
 
     glutInit( &argc, argv );

--- a/markup.h
+++ b/markup.h
@@ -40,6 +40,10 @@ extern "C" {
 #include "texture-font.h"
 #include "vec234.h"
 
+#ifdef __cplusplus
+namespace ftgl {
+#endif
+
 /**
  * @file   markup.h
  * @author Nicolas Rougier (Nicolas.Rougier@inria.fr)
@@ -185,6 +189,7 @@ extern markup_t default_markup;
 /** @} */
 
 #ifdef __cplusplus
+}
 }
 #endif
 

--- a/shaders/text.frag
+++ b/shaders/text.frag
@@ -77,7 +77,7 @@ energy_distribution( vec4 previous, vec4 current, vec4 next )
     return vec3(r,g,b);
 }
 
-uniform sampler2D texture;
+uniform sampler2D tex;
 uniform vec3 pixel;
 
 varying vec4 vcolor;
@@ -90,15 +90,15 @@ void main()
     // LCD Off
     if( pixel.z == 1.0)
     {
-        float a = texture2D(texture, vtex_coord).r;
+        float a = texture2D(tex, vtex_coord).r;
         gl_FragColor = vcolor * pow( a, 1.0/vgamma );
         return;
     }
 
     // LCD On
-    vec4 current = texture2D(texture, vtex_coord);
-    vec4 previous= texture2D(texture, vtex_coord+vec2(-1.,0.)*pixel.xy);
-    vec4 next    = texture2D(texture, vtex_coord+vec2(+1.,0.)*pixel.xy);
+    vec4 current = texture2D(tex, vtex_coord);
+    vec4 previous= texture2D(tex, vtex_coord+vec2(-1.,0.)*pixel.xy);
+    vec4 next    = texture2D(tex, vtex_coord+vec2(+1.,0.)*pixel.xy);
 
     current = pow(current, vec4(1.0/vgamma));
     previous= pow(previous, vec4(1.0/vgamma));

--- a/shaders/text.vert
+++ b/shaders/text.vert
@@ -31,7 +31,7 @@
  * policies, either expressed or implied, of Nicolas P. Rougier.
  * ============================================================================
  */
-uniform sampler2D texture;
+uniform sampler2D tex;
 uniform vec3 pixel;
 uniform mat4 model;
 uniform mat4 view;

--- a/text-buffer.c
+++ b/text-buffer.c
@@ -82,7 +82,7 @@ text_buffer_new_with_program( size_t depth,
                                      "vertex:3f,tex_coord:2f,color:4f,ashift:1f,agamma:1f" );
     self->manager = font_manager_new( 512, 512, depth );
     self->shader = program;
-    self->shader_texture = glGetUniformLocation(self->shader, "texture");
+    self->shader_texture = glGetUniformLocation(self->shader, "tex");
     self->shader_pixel = glGetUniformLocation(self->shader, "pixel");
     self->line_start = 0;
     self->line_ascender = 0;

--- a/text-buffer.c
+++ b/text-buffer.c
@@ -206,7 +206,7 @@ text_buffer_move_last_line( text_buffer_t * self, float dy )
 void
 text_buffer_add_text( text_buffer_t * self,
                       vec2 * pen, markup_t * markup,
-                      wchar_t * text, size_t length )
+                      const wchar_t * text, size_t length )
 {
     font_manager_t * manager = self->manager;
     size_t i;

--- a/text-buffer.c
+++ b/text-buffer.c
@@ -153,6 +153,8 @@ text_buffer_render( text_buffer_t * self )
                  1.0/self->manager->atlas->height,
                  self->manager->atlas->depth );
     vertex_buffer_render( self->buffer, GL_TRIANGLES );
+    glBindTexture( GL_TEXTURE_2D, 0 );
+    glBlendColor( 0, 0, 0, 0 );
     glUseProgram( 0 );
 }
 

--- a/text-buffer.c
+++ b/text-buffer.c
@@ -64,12 +64,24 @@ text_buffer_new_with_shaders( size_t depth,
                               const char * vert_filename,
                               const char * frag_filename )
 {
+    GLuint program = shader_load( vert_filename, frag_filename );
+
+    text_buffer_t * p = text_buffer_new_with_program( depth, program );
+
+    return p;
+}
+
+// ----------------------------------------------------------------------------
+
+text_buffer_t *
+text_buffer_new_with_program( size_t depth,
+                                    GLuint program )
+{
     text_buffer_t *self = (text_buffer_t *) malloc (sizeof(text_buffer_t));
     self->buffer = vertex_buffer_new(
                                      "vertex:3f,tex_coord:2f,color:4f,ashift:1f,agamma:1f" );
     self->manager = font_manager_new( 512, 512, depth );
-    self->shader = shader_load(vert_filename,
-                               frag_filename);
+    self->shader = program;
     self->shader_texture = glGetUniformLocation(self->shader, "texture");
     self->shader_pixel = glGetUniformLocation(self->shader, "pixel");
     self->line_start = 0;

--- a/text-buffer.h
+++ b/text-buffer.h
@@ -241,14 +241,14 @@ typedef struct glyph_vertex_t {
   text_buffer_new_with_program( size_t depth,
                                 GLuint program );
 
-  /**
-  * Deletes texture buffer and its associated shader and vertex buffer.
-  *
-  * @param  self  texture buffer to delete
-  *
-  */
-void
-text_buffer_delete( text_buffer_t * self );
+/**
+ * Deletes texture buffer and its associated shader and vertex buffer.
+ *
+ * @param  self  texture buffer to delete
+ *
+ */
+  void
+  text_buffer_delete( text_buffer_t * self );
 
 /**
  * Render a text buffer.

--- a/text-buffer.h
+++ b/text-buffer.h
@@ -284,7 +284,7 @@ typedef struct glyph_vertex_t {
   void
   text_buffer_add_text( text_buffer_t * self,
                         vec2 * pen, markup_t * markup,
-                        wchar_t * text, size_t length );
+                        const wchar_t * text, size_t length );
 
  /**
   * Add a char to the text buffer

--- a/text-buffer.h
+++ b/text-buffer.h
@@ -228,6 +228,19 @@ typedef struct glyph_vertex_t {
                                 const char * vert_filename,
                                 const char * frag_filename );
 
+/**
+ * Creates a new empty text buffer using custom shaders.
+ *
+ * @param depth          Underlying atlas bit depth (1 or 3)
+ * @param program        Shader program
+ *
+ * @return  a new empty text buffer.
+ *
+ */
+  text_buffer_t *
+  text_buffer_new_with_program( size_t depth,
+                                GLuint program );
+
   /**
   * Deletes texture buffer and its associated shader and vertex buffer.
   *

--- a/vertex-buffer.c
+++ b/vertex-buffer.c
@@ -407,6 +407,21 @@ vertex_buffer_render_setup ( vertex_buffer_t *self, GLenum mode )
 void
 vertex_buffer_render_finish ( vertex_buffer_t *self )
 {
+    int i;
+
+    for( i=0; i<MAX_VERTEX_ATTRIBUTE; ++i )
+    {
+        vertex_attribute_t *attribute = self->attributes[i];
+        if( attribute == 0 )
+        {
+            continue;
+        }
+        else
+        {
+            glDisableVertexAttribArray( attribute->index );
+        }
+    }
+
 #ifdef FREETYPE_GL_USE_VAO
     glBindVertexArray( 0 );
 #else


### PR DESCRIPTION
vertex-buffer, text-buffer: restore modified OpenGL states after rendering.

makefont: allow arbitrary texture sizes instead of the default 128x128 to build embedded textures of higher resolution.

text-buffer: specifying filenames of shaders prevents the use of embedded shaders, this is resolved by allowing the user to build the embedded shader and provide a linked GLSL program instead.