### PR TITLE
Increased OpenGL ES compatibility

### DIFF
--- a/harfbuzz/demo-harfbuzz.c
+++ b/harfbuzz/demo-harfbuzz.c
@@ -232,7 +232,7 @@ int main( int argc, char **argv )
                 {x0,y1,0, s0,t1, r,g,b,a, shift, gamma},
                 {x1,y1,0, s1,t1, r,g,b,a, shift, gamma},
                 {x1,y0,0, s1,t0, r,g,b,a, shift, gamma} };
-            GLuint indices[6] = { 0,1,2, 0,2,3 };
+            GLushort indices[6] = { 0,1,2, 0,2,3 };
             vertex_buffer_push_back( vbuffer, vertices, 4, indices, 6 );
             x += x_advance;
             y += y_advance;
@@ -244,7 +244,6 @@ int main( int argc, char **argv )
     glClearColor(1,1,1,1);
     glEnable( GL_BLEND );
     glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
-    glEnable( GL_TEXTURE_2D );
     glBindTexture( GL_TEXTURE_2D, atlas->id );
     texture_atlas_upload( atlas );
     vertex_buffer_upload( vbuffer );

--- a/texture-atlas.c
+++ b/texture-atlas.c
@@ -338,8 +338,8 @@ texture_atlas_upload( texture_atlas_t * self )
     }
     else
     {
-        glTexImage2D( GL_TEXTURE_2D, 0, GL_RED, self->width, self->height,
-                      0, GL_RED, GL_UNSIGNED_BYTE, self->data );
+        glTexImage2D( GL_TEXTURE_2D, 0, GL_LUMINANCE, self->width, self->height,
+                      0, GL_LUMINANCE, GL_UNSIGNED_BYTE, self->data );
     }
 }
 

--- a/vertex-buffer.c
+++ b/vertex-buffer.c
@@ -120,7 +120,7 @@ vertex_buffer_new( const char *format )
     self->vertices_id  = 0;
     self->GPU_vsize = 0;
 
-    self->indices = vector_new( sizeof(GLuint) );
+    self->indices = vector_new( sizeof(GLushort) );
     self->indices_id  = 0;
     self->GPU_isize = 0;
 
@@ -445,7 +445,7 @@ vertex_buffer_render_item ( vertex_buffer_t *self,
     {
         size_t start = item->istart;
         size_t count = item->icount;
-        glDrawElements( self->mode, count, GL_UNSIGNED_INT, (void *)(start*sizeof(GLuint)) );
+        glDrawElements( self->mode, count, GL_UNSIGNED_SHORT, (void *)(start*sizeof(GLushort)) );
     }
     else if( self->vertices->size )
     {
@@ -466,7 +466,7 @@ vertex_buffer_render ( vertex_buffer_t *self, GLenum mode )
     vertex_buffer_render_setup( self, mode );
     if( icount )
     {
-        glDrawElements( mode, icount, GL_UNSIGNED_INT, 0 );
+        glDrawElements( mode, icount, GL_UNSIGNED_SHORT, 0 );
     }
     else
     {
@@ -480,7 +480,7 @@ vertex_buffer_render ( vertex_buffer_t *self, GLenum mode )
 // ----------------------------------------------------------------------------
 void
 vertex_buffer_push_back_indices ( vertex_buffer_t * self,
-                                  const GLuint * indices,
+                                  const GLushort * indices,
                                   const size_t icount )
 {
     assert( self );
@@ -509,7 +509,7 @@ vertex_buffer_push_back_vertices ( vertex_buffer_t * self,
 void
 vertex_buffer_insert_indices ( vertex_buffer_t *self,
                                const size_t index,
-                               const GLuint *indices,
+                               const GLushort *indices,
                                const size_t count )
 {
     assert( self );
@@ -538,9 +538,9 @@ vertex_buffer_insert_vertices( vertex_buffer_t *self,
 
      for( i=0; i<self->indices->size; ++i )
     {
-        if( *(GLuint *)(vector_get( self->indices, i )) > index )
+        if( *(GLushort *)(vector_get( self->indices, i )) > index )
         {
-            *(GLuint *)(vector_get( self->indices, i )) += index;
+            *(GLushort *)(vector_get( self->indices, i )) += index;
         }
     }
 
@@ -582,9 +582,9 @@ vertex_buffer_erase_vertices( vertex_buffer_t *self,
     self->state |= DIRTY;
     for( i=0; i<self->indices->size; ++i )
     {
-        if( *(GLuint *)(vector_get( self->indices, i )) > first )
+        if( *(GLushort *)(vector_get( self->indices, i )) > first )
         {
-            *(GLuint *)(vector_get( self->indices, i )) -= (last-first);
+            *(GLushort *)(vector_get( self->indices, i )) -= (last-first);
         }
     }
     vector_erase_range( self->vertices, first, last );
@@ -596,7 +596,7 @@ vertex_buffer_erase_vertices( vertex_buffer_t *self,
 size_t
 vertex_buffer_push_back( vertex_buffer_t * self,
                          const void * vertices, const size_t vcount,
-                         const GLuint * indices, const size_t icount )
+                         const GLushort * indices, const size_t icount )
 {
     return vertex_buffer_insert( self, vector_size( self->items ),
                                  vertices, vcount, indices, icount );
@@ -606,7 +606,7 @@ vertex_buffer_push_back( vertex_buffer_t * self,
 size_t
 vertex_buffer_insert( vertex_buffer_t * self, const size_t index,
                       const void * vertices, const size_t vcount,
-                      const GLuint * indices, const size_t icount )
+                      const GLushort * indices, const size_t icount )
 {
     size_t vstart, istart, i;
     ivec4 item;
@@ -627,7 +627,7 @@ vertex_buffer_insert( vertex_buffer_t * self, const size_t index,
     // Update indices within the vertex buffer
     for( i=0; i<icount; ++i )
     {
-        *(GLuint *)(vector_get( self->indices, istart+i )) += vstart;
+        *(GLushort *)(vector_get( self->indices, istart+i )) += vstart;
     }
 
     // Insert item

--- a/vertex-buffer.h
+++ b/vertex-buffer.h
@@ -221,7 +221,7 @@ typedef struct vertex_buffer_t
  */
   void
   vertex_buffer_push_back_indices ( vertex_buffer_t *self,
-                                    const GLuint * indices,
+                                    const GLushort * indices,
                                     const size_t icount );
 
 
@@ -255,7 +255,7 @@ typedef struct vertex_buffer_t
   void
   vertex_buffer_insert_indices ( vertex_buffer_t *self,
                                  const size_t index,
-                                 const GLuint *indices,
+                                 const GLushort *indices,
                                  const size_t icount );
 
 
@@ -316,7 +316,7 @@ typedef struct vertex_buffer_t
   size_t
   vertex_buffer_push_back( vertex_buffer_t * self,
                            const void * vertices, const size_t vcount,
-                           const GLuint * indices, const size_t icount );
+                           const GLushort * indices, const size_t icount );
 
 
 /**
@@ -333,7 +333,7 @@ typedef struct vertex_buffer_t
   vertex_buffer_insert( vertex_buffer_t * self,
                         const size_t index,
                         const void * vertices, const size_t vcount,
-                        const GLuint * indices, const size_t icount );
+                        const GLushort * indices, const size_t icount );
 
 /**
  * Erase an item from the vertex buffer.


### PR DESCRIPTION
change indices from unsigned int to unsigned short since glDrawElements doesn't support GL_UNSIGNED_INT unless you have the GL_OES_element_index_uint extension
change GL_RED to GL_LUMINANCE since GL_RED doesn't exist in OpenGL ES