### PR TITLE
Add GLES 3 support for iOS.

### DIFF
--- a/opengl.h
+++ b/opengl.h
@@ -35,11 +35,16 @@
 #define __OPEN_GL_H__
 
 #if defined(__APPLE__)
-#  ifdef GL_ES_VERSION_2_0
-#    include <OpenGLES/ES2/gl.h>
-#  else
-#    include <OpenGL/gl.h>
-#  endif
+#   include "TargetConditionals.h"
+#   if TARGET_OS_SIMULATOR || TARGET_OS_IPHONE
+#     if defined(FREETYPE_GL_ES_VERSION_3_0)
+#       include <OpenGLES/ES3/gl.h>
+#     else
+#       include <OpenGLES/ES2/gl.h>
+#     endif
+#   else
+#     include <OpenGL/gl.h>
+#   endif
 #elif defined(_WIN32) || defined(_WIN64)
 #  include <GL/glew.h>
 #  include <GL/wglew.h>

--- a/texture-atlas.c
+++ b/texture-atlas.c
@@ -338,8 +338,13 @@ texture_atlas_upload( texture_atlas_t * self )
     }
     else
     {
+#if defined(GL_ES_VERSION_2_0) && !defined(GL_ES_VERSION_3_0)
+        glTexImage2D( GL_TEXTURE_2D, 0, GL_LUMINANCE, self->width, self->height,
+                      0, GL_LUMINANCE, GL_UNSIGNED_BYTE, self->data );
+#else
         glTexImage2D( GL_TEXTURE_2D, 0, GL_RED, self->width, self->height,
-                      0, GL_RED, GL_UNSIGNED_BYTE, self->data );
+                     0, GL_RED, GL_UNSIGNED_BYTE, self->data );
+#endif
     }
 }
 


### PR DESCRIPTION
Fix GLES 2 support - GL_RED does not exist in GLES 2.

When freetype-gl is built, neither the macro ```GL_ES_VERSION_3_0``` nor ```GL_ES_VERSION_2_0``` is ever set. Counterintuitively, these get set in ```<OpenGLES/ES3/gl.h>``` and ```<OpenGLES/ES2/gl.h>```. Therefore I've added a custom preprocessor macro that can be set as part of the build process ```FREETYPE_GL_ES_VERSION_3_0``` which will force GLES3 for iOS if it is set. Otherwise, builds for iOS will fall back to GLES2.