### PR TITLE
Make glfw optional so that it can be provided by parent build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ OPTION(freetype-gl_BUILD_DEMOS "Build the freetype-gl example programs" ON)
 OPTION(freetype-gl_BUILD_APIDOC "Build the freetype-gl API documentation" ON)
 OPTION(freetype-gl_BUILD_HARFBUZZ "Build the freetype-gl harfbuzz support (experimental)" OFF)
 OPTION(freetype-gl_LIBS_SUPPLIED "Required libraries are supplied as part of parent build" OFF)
+OPTION(freetype-gl_GLFW_SUPPLIED "GLFW library is supplied as part of parent build" OFF)
 
 # Get required and optional library
 FIND_PACKAGE( OpenGL REQUIRED )
@@ -75,7 +76,9 @@ ELSE( WIN32 OR WIN64 )
     FIND_LIBRARY( MATH_LIBRARY m )
 ENDIF( WIN32 OR WIN64 )
 
-FIND_PACKAGE( glfw3 REQUIRED )
+IF ( NOT freetype-gl_LIBS_SUPPLIED )
+    FIND_PACKAGE( glfw3 REQUIRED )
+ENDIF ( NOT freetype-gl_LIBS_SUPPLIED )
 
 INCLUDE_DIRECTORIES( ${GLFW3_INCLUDE_DIR}
                      ${OPENGL_INCLUDE_DIRS}


### PR DESCRIPTION
The use case is that glfw is not installed on the machine and is being built as part of the parent build process. The default is the same as the current setting - to require glfw libraries.

An example of how to do this from the parent CMakeLists.txt:

```
# Build glfw
OPTION(GLFW_BUILD_EXAMPLES "Build the GLFW example programs" OFF)
OPTION(GLFW_BUILD_TESTS "Build the GLFW test programs" OFF)
OPTION(GLFW_BUILD_DOCS "Build the GLFW documentation" OFF)
OPTION(GLFW_INSTALL "Generate installation target" OFF)

ADD_SUBDIRECTORY(lib/glfw)

# Build freetype-gl
OPTION(freetype-gl_BUILD_DEMOS "Build the freetype-gl example programs" OFF)
OPTION(freetype-gl_BUILD_APIDOC "Build the freetype-gl API documentation" OFF)
OPTION(freetype-gl_LIBS_SUPPLIED "Required libraries are supplied as part of parent build" ON)
OPTION(freetype-gl_GLFW_SUPPLIED "GLFW library is supplied as part of parent build" ON)

# These variables are used in the freetype-gl build:
SET(GLFW3_INCLUDE_DIR "${MAINFOLDER}/lib/glfw/include")
SET(GLFW3_LIBRARY "glfw;${GLFW_LIBRARIES}")

ADD_SUBDIRECTORY(lib/freetype-gl)
```