### PR TITLE
Fixes text not displaying in GLES3

### DIFF
--- a/texture-atlas.c
+++ b/texture-atlas.c
@@ -338,7 +338,7 @@ texture_atlas_upload( texture_atlas_t * self )
     }
     else
     {
-#if defined(GL_ES_VERSION_2_0) && !defined(GL_ES_VERSION_3_0)
+#if defined(GL_ES_VERSION_2_0) || defined(GL_ES_VERSION_3_0)
         glTexImage2D( GL_TEXTURE_2D, 0, GL_LUMINANCE, self->width, self->height,
                       0, GL_LUMINANCE, GL_UNSIGNED_BYTE, self->data );
 #else


### PR DESCRIPTION
Currently text is not displayed when using GLES3. This is because the call to glTexImage2D is incorrect: ```GL_LUMINANCE``` is used for GLES2 and ```GL_RED``` for GLES3. [According to the documentation][1] for this function in GLES 3, ```GL_LUMINANCE``` should be used.

This condition was added by my PR (https://github.com/rougier/freetype-gl/pull/80) but only covered GLES2.

[1]: https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage2D.xhtml