### PR TITLE
Use UTF-8 encoded parameters for the various public functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ SET( FREETYPE_GL_SRC freetype-gl.h
                      text-buffer.c      text-buffer.h
                      shader.c           shader.h
                      vector.c           vector.h
+                     utf8-utils.c       utf8-utils.h
                      platform.c         platform.h
                      edtaa3func.c       edtaa3func.h)
 

--- a/demos/ansi.c
+++ b/demos/ansi.c
@@ -41,6 +41,7 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -287,7 +288,9 @@ print( text_buffer_t * buffer, vec2 * pen,
             }
             ansi_to_markup(seq_start, seq_size, markup );
             markup->font = font_manager_get_from_markup( buffer->manager, markup );
-            text_buffer_add_text( buffer, pen, markup, text_start, text_size );
+            char * utext = str_utf16_to_utf8( text_start );
+            text_buffer_add_text( buffer, pen, markup, utext, text_size );
+            free( utext );
         }
     }
 }

--- a/demos/atb-agg.c
+++ b/demos/atb-agg.c
@@ -40,6 +40,7 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -188,7 +189,9 @@ build_buffer( void )
     font->lcd_weights[4] = (unsigned char)(p_tertiary*norm*256);
     pen.x = 10;
     pen.y = 600 - font->height - 10;
-    text_buffer_printf( buffer, &pen, &markup, text, NULL );
+    char * utext = str_utf16_to_utf8( text );
+    text_buffer_printf( buffer, &pen, &markup, utext, NULL );
+    free( utext );
 
     // Post-processing for width and orientation
     vertex_buffer_t * vbuffer = buffer->buffer;

--- a/demos/atb-agg.c
+++ b/demos/atb-agg.c
@@ -40,7 +40,6 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
-#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -84,22 +83,22 @@ float p_primary;
 float p_secondary;
 float p_tertiary;
 
-static wchar_t text[] =
-    L"A single pixel on a color LCD is made of three colored elements \n"
-    L"ordered (on various displays) either as blue, green, and red (BGR), \n"
-    L"or as red, green, and blue (RGB). These pixel components, sometimes \n"
-    L"called sub-pixels, appear as a single color to the human eye because \n"
-    L"of blurring by the optics and spatial integration by nerve cells in "
-    L"the eye.\n"
-    L"\n"
-    L"The resolution at which colored sub-pixels go unnoticed differs, \n"
-    L"however, with each user some users are distracted by the colored \n"
-    L"\"fringes\" resulting from sub-pixel rendering. Subpixel rendering \n"
-    L"is better suited to some display technologies than others. The \n"
-    L"technology is well-suited to LCDs, but less so for CRTs. In a CRT \n"
-    L"the light from the pixel components often spread across pixels, \n"
-    L"and the outputs of adjacent pixels are not perfectly independent."
-    L"\n";
+static char text[] =
+    "A single pixel on a color LCD is made of three colored elements \n"
+    "ordered (on various displays) either as blue, green, and red (BGR), \n"
+    "or as red, green, and blue (RGB). These pixel components, sometimes \n"
+    "called sub-pixels, appear as a single color to the human eye because \n"
+    "of blurring by the optics and spatial integration by nerve cells in "
+    "the eye.\n"
+    "\n"
+    "The resolution at which colored sub-pixels go unnoticed differs, \n"
+    "however, with each user some users are distracted by the colored \n"
+    "\"fringes\" resulting from sub-pixel rendering. Subpixel rendering \n"
+    "is better suited to some display technologies than others. The \n"
+    "technology is well-suited to LCDs, but less so for CRTs. In a CRT \n"
+    "the light from the pixel components often spread across pixels, \n"
+    "and the outputs of adjacent pixels are not perfectly independent."
+    "\n";
 
 
 // ----------------------------------------------------------- build_buffer ---
@@ -189,9 +188,7 @@ build_buffer( void )
     font->lcd_weights[4] = (unsigned char)(p_tertiary*norm*256);
     pen.x = 10;
     pen.y = 600 - font->height - 10;
-    char * utext = str_utf16_to_utf8( text );
-    text_buffer_printf( buffer, &pen, &markup, utext, NULL );
-    free( utext );
+    text_buffer_printf( buffer, &pen, &markup, text, NULL );
 
     // Post-processing for width and orientation
     vertex_buffer_t * vbuffer = buffer->buffer;

--- a/demos/benchmark.c
+++ b/demos/benchmark.c
@@ -32,12 +32,11 @@
  * ============================================================================
  */
 #include <stdio.h>
-#include <wchar.h>
+#include <string.h>
 #include "freetype-gl.h"
 #include "vertex-buffer.h"
 #include "shader.h"
 #include "mat4.h"
-#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -54,9 +53,9 @@ typedef struct {
 texture_atlas_t * atlas;
 texture_font_t * font;
 vertex_buffer_t * buffer;
-wchar_t *text =
-    L"A Quick Brown Fox Jumps Over The Lazy Dog 0123456789 "
-    L"A Quick Brown Fox Jumps Over The Lazy Dog 0123456789 ";
+char *text =
+    "A Quick Brown Fox Jumps Over The Lazy Dog 0123456789 "
+    "A Quick Brown Fox Jumps Over The Lazy Dog 0123456789 ";
 int line_count = 42;
 GLuint shader;
 mat4   model, view, projection;
@@ -64,23 +63,19 @@ mat4   model, view, projection;
 
 // --------------------------------------------------------------- add_text ---
 void add_text( vertex_buffer_t * buffer, texture_font_t * font,
-               wchar_t * text, vec4 * color, vec2 * pen )
+               char *text, vec4 * color, vec2 * pen )
 {
     size_t i;
     float r = color->red, g = color->green, b = color->blue, a = color->alpha;
-    for( i=0; i<wcslen(text); ++i )
+    for( i = 0; i < strlen(text); ++i )
     {
-        char * character = utf16_to_utf8( text[i] );
-        texture_glyph_t *glyph = texture_font_get_glyph( font, character );
-        free( character );
+        texture_glyph_t *glyph = texture_font_get_glyph( font, text + i );
         if( glyph != NULL )
         {
             float kerning = 0.0f;
             if( i > 0)
             {
-                char * character = utf16_to_utf8( text[i-1] );
-                kerning = texture_glyph_get_kerning( glyph, character );
-                free( character );
+                kerning = texture_glyph_get_kerning( glyph, text + i - 1 );
             }
             pen->x += kerning;
             int x0  = (int)( pen->x + glyph->offset_x );
@@ -118,7 +113,7 @@ void display( GLFWwindow* window )
         printf(
             "Computing FPS with text generation and rendering at each frame...\n" );
         printf(
-            "Number of glyphs: %d\n", (int)wcslen(text)*line_count );
+            "Number of glyphs: %d\n", (int)strlen(text)*line_count );
     }
 
 	frame++;
@@ -128,14 +123,14 @@ void display( GLFWwindow* window )
     {
         printf( "FPS : %.2f (%d frames in %.2f second, %.1f glyph/second)\n",
                 frame/time, frame, time,
-                frame/time * wcslen(text)*line_count );
+                frame/time * strlen(text)*line_count );
         glfwSetTime( 0.0 );
         frame = 0;
         ++count;
         if( count == 5 )
         {
             printf( "\nComputing FPS with text rendering at each frame...\n" );
-            printf( "Number of glyphs: %d\n", (int)wcslen(text)*line_count );
+            printf( "Number of glyphs: %d\n", (int)strlen(text)*line_count );
         }
         if( count > 9 )
         {

--- a/demos/benchmark.c
+++ b/demos/benchmark.c
@@ -37,6 +37,7 @@
 #include "vertex-buffer.h"
 #include "shader.h"
 #include "mat4.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -69,7 +70,9 @@ void add_text( vertex_buffer_t * buffer, texture_font_t * font,
     float r = color->red, g = color->green, b = color->blue, a = color->alpha;
     for( i=0; i<wcslen(text); ++i )
     {
-        texture_glyph_t *glyph = texture_font_get_glyph( font, text[i] );
+        char * character = utf16_to_utf8( text[i] );
+        texture_glyph_t *glyph = texture_font_get_glyph( font, character );
+        free( character );
         if( glyph != NULL )
         {
             float kerning = 0.0f;

--- a/demos/benchmark.c
+++ b/demos/benchmark.c
@@ -78,7 +78,9 @@ void add_text( vertex_buffer_t * buffer, texture_font_t * font,
             float kerning = 0.0f;
             if( i > 0)
             {
-                kerning = texture_glyph_get_kerning( glyph, text[i-1] );
+                char * character = utf16_to_utf8( text[i-1] );
+                kerning = texture_glyph_get_kerning( glyph, character );
+                free( character );
             }
             pen->x += kerning;
             int x0  = (int)( pen->x + glyph->offset_x );

--- a/demos/cartoon.c
+++ b/demos/cartoon.c
@@ -39,6 +39,7 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -109,7 +110,9 @@ void add_text( vertex_buffer_t * buffer, texture_font_t * font,
     size_t i;
     for( i=0; i<wcslen(text); ++i )
     {
-        texture_glyph_t *glyph = texture_font_get_glyph( font, text[i] );
+        char * character = utf16_to_utf8( text[i] );
+        texture_glyph_t *glyph = texture_font_get_glyph( font, character );
+        free( character );
         float kerning = 0.0f;
         if( i > 0)
         {

--- a/demos/cartoon.c
+++ b/demos/cartoon.c
@@ -31,7 +31,7 @@
  * policies, either expressed or implied, of Nicolas P. Rougier.
  * ========================================================================= */
 #include <stdio.h>
-#include <wchar.h>
+#include <string.h>
 
 #include "freetype-gl.h"
 
@@ -39,7 +39,6 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
-#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -105,20 +104,16 @@ void keyboard( GLFWwindow* window, int key, int scancode, int action, int mods )
 
 // --------------------------------------------------------------- add_text ---
 void add_text( vertex_buffer_t * buffer, texture_font_t * font,
-               wchar_t *text, vec2 pen, vec4 fg_color_1, vec4 fg_color_2 )
+               char *text, vec2 pen, vec4 fg_color_1, vec4 fg_color_2 )
 {
     size_t i;
-    for( i=0; i<wcslen(text); ++i )
+    for( i = 0; i < strlen(text); ++i )
     {
-        char * character = utf16_to_utf8( text[i] );
-        texture_glyph_t *glyph = texture_font_get_glyph( font, character );
-        free( character );
+        texture_glyph_t *glyph = texture_font_get_glyph( font, text + i );
         float kerning = 0.0f;
         if( i > 0)
         {
-            char * character = utf16_to_utf8( text[i-1] );
-            kerning = texture_glyph_get_kerning( glyph, character );
-            free( character );
+            kerning = texture_glyph_get_kerning( glyph, text + i - 1 );
         }
         pen.x += kerning;
 
@@ -207,19 +202,19 @@ int main( int argc, char **argv )
 
     font->outline_type = 2;
     font->outline_thickness = 7;
-    add_text( buffer, font, L"Freetype GL", pen, black, black );
+    add_text( buffer, font, "Freetype GL", pen, black, black );
 
     font->outline_type = 2;
     font->outline_thickness = 5;
-    add_text( buffer, font, L"Freetype GL", pen, yellow, yellow );
+    add_text( buffer, font, "Freetype GL", pen, yellow, yellow );
 
     font->outline_type = 1;
     font->outline_thickness = 3;
-    add_text( buffer, font, L"Freetype GL", pen, black, black );
+    add_text( buffer, font, "Freetype GL", pen, black, black );
 
     font->outline_type = 0;
     font->outline_thickness = 0;
-    add_text( buffer, font, L"Freetype GL", pen, orange1, orange2 );
+    add_text( buffer, font, "Freetype GL", pen, orange1, orange2 );
 
     shader = shader_load("shaders/v3f-t2f-c4f.vert",
                          "shaders/v3f-t2f-c4f.frag");

--- a/demos/cartoon.c
+++ b/demos/cartoon.c
@@ -116,7 +116,9 @@ void add_text( vertex_buffer_t * buffer, texture_font_t * font,
         float kerning = 0.0f;
         if( i > 0)
         {
-            kerning = texture_glyph_get_kerning( glyph, text[i-1] );
+            char * character = utf16_to_utf8( text[i-1] );
+            kerning = texture_glyph_get_kerning( glyph, character );
+            free( character );
         }
         pen.x += kerning;
 

--- a/demos/console.c
+++ b/demos/console.c
@@ -38,6 +38,7 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -203,7 +204,9 @@ console_add_glyph( console_t *self,
                    wchar_t previous,
                    markup_t *markup )
 {
-    texture_glyph_t *glyph  = texture_font_get_glyph( markup->font, current );
+    char * character = utf16_to_utf8( current );
+    texture_glyph_t *glyph  = texture_font_get_glyph( markup->font, character );
+    free( character );
     if( previous != L'\0' )
     {
         self->pen.x += texture_glyph_get_kerning( glyph, previous );
@@ -303,8 +306,8 @@ console_render( console_t *self )
         }
     }
 
-    // Cursor (we use the black character (-1) as texture )
-    texture_glyph_t *glyph  = texture_font_get_glyph( markup.font, -1 );
+    // Cursor (we use the black character (NULL) as texture )
+    texture_glyph_t *glyph  = texture_font_get_glyph( markup.font, NULL );
     float r = markup.foreground_color.r;
     float g = markup.foreground_color.g;
     float b = markup.foreground_color.b;

--- a/demos/console.c
+++ b/demos/console.c
@@ -209,7 +209,9 @@ console_add_glyph( console_t *self,
     free( character );
     if( previous != L'\0' )
     {
-        self->pen.x += texture_glyph_get_kerning( glyph, previous );
+        char * character = utf16_to_utf8( previous );
+        self->pen.x += texture_glyph_get_kerning( glyph, character );
+        free( character );
     }
     float r = markup->foreground_color.r;
     float g = markup->foreground_color.g;

--- a/demos/distance-field-2.c
+++ b/demos/distance-field-2.c
@@ -41,6 +41,7 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -146,7 +147,9 @@ add_text( vertex_buffer_t * buffer, texture_font_t * font,
     float r = color->red, g = color->green, b = color->blue, a = color->alpha;
     for( i=0; i<wcslen(text); ++i )
     {
-        texture_glyph_t *glyph = texture_font_get_glyph( font, text[i] );
+        char * character = utf16_to_utf8( text[i] );
+        texture_glyph_t *glyph = texture_font_get_glyph( font, character );
+        free( character );
         if( glyph != NULL )
         {
             float kerning = 0.0f;

--- a/demos/distance-field-2.c
+++ b/demos/distance-field-2.c
@@ -155,7 +155,9 @@ add_text( vertex_buffer_t * buffer, texture_font_t * font,
             float kerning = 0.0f;
             if( i > 0)
             {
-                kerning = texture_glyph_get_kerning( glyph, text[i-1] );
+                char * character = utf16_to_utf8( text[i-1] );
+                kerning = texture_glyph_get_kerning( glyph, character );
+                free( character );
             }
             pen->x += kerning;
             int x0  = (int)( pen->x + glyph->offset_x );

--- a/demos/distance-field-2.c
+++ b/demos/distance-field-2.c
@@ -32,7 +32,6 @@
  * ========================================================================= */
 #include <stdio.h>
 #include <string.h>
-#include <wchar.h>
 
 #include "freetype-gl.h"
 #include "edtaa3func.h"
@@ -41,7 +40,6 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
-#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -140,24 +138,20 @@ void keyboard( GLFWwindow* window, int key, int scancode, int action, int mods )
 // --------------------------------------------------------------- add_text ---
 vec4
 add_text( vertex_buffer_t * buffer, texture_font_t * font,
-          wchar_t * text, vec4 * color, vec2 * pen )
+          char *text, vec4 * color, vec2 * pen )
 {
     vec4 bbox = {{0,0,0,0}};
     size_t i;
     float r = color->red, g = color->green, b = color->blue, a = color->alpha;
-    for( i=0; i<wcslen(text); ++i )
+    for( i = 0; i < strlen(text); ++i )
     {
-        char * character = utf16_to_utf8( text[i] );
-        texture_glyph_t *glyph = texture_font_get_glyph( font, character );
-        free( character );
+        texture_glyph_t *glyph = texture_font_get_glyph( font, text + i );
         if( glyph != NULL )
         {
             float kerning = 0.0f;
             if( i > 0)
             {
-                char * character = utf16_to_utf8( text[i-1] );
-                kerning = texture_glyph_get_kerning( glyph, character );
-                free( character );
+                kerning = texture_glyph_get_kerning( glyph, text + i - 1 );
             }
             pen->x += kerning;
             int x0  = (int)( pen->x + glyph->offset_x );
@@ -307,7 +301,7 @@ int main( int argc, char **argv )
     texture_font_t *font = 0;
     texture_atlas_t *atlas = texture_atlas_new( 512, 512, 1 );
     const char * filename = "fonts/Vera.ttf";
-    wchar_t *text = L"A Quick Brown Fox Jumps Over The Lazy Dog 0123456789";
+    char *text = "A Quick Brown Fox Jumps Over The Lazy Dog 0123456789";
     buffer = vertex_buffer_new( "vertex:3f,tex_coord:2f,color:4f" );
     vec2 pen = {{0,0}};
     vec4 black = {{1,1,1,1}};

--- a/demos/distance-field-3.c
+++ b/demos/distance-field-3.c
@@ -38,6 +38,7 @@
 #include "texture-font.h"
 #include "texture-atlas.h"
 #include "platform.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -289,7 +290,7 @@ void keyboard( GLFWwindow* window, int key, int scancode, int action, int mods )
 
 // ------------------------------------------------------------- load_glyph ---
 texture_glyph_t *
-load_glyph( const char *  filename,     const wchar_t charcode,
+load_glyph( const char *  filename,     const char* charcode,
             const float   highres_size, const float   lowres_size,
             const float   padding )
 {
@@ -300,7 +301,7 @@ load_glyph( const char *  filename,     const wchar_t charcode,
     FT_Init_FreeType( &library );
     FT_New_Face( library, filename, 0, &face );
     FT_Select_Charmap( face, FT_ENCODING_UNICODE );
-    FT_UInt glyph_index = FT_Get_Char_Index( face, charcode );
+    FT_UInt glyph_index = FT_Get_Char_Index( face, utf8_to_utf32( charcode ) );
 
     // Render glyph at high resolution (highres_size points)
     FT_Set_Char_Size( face, highres_size*64, 0, 72, 72 );
@@ -362,7 +363,7 @@ load_glyph( const char *  filename,     const wchar_t charcode,
     glyph->offset_y = (slot->bitmap_top + padding*highres_height) * ratio;
     glyph->width    = lowres_width;
     glyph->height   = lowres_height;
-    glyph->charcode = charcode;
+    glyph->charcode = utf8_to_utf32( charcode );
     /*
     printf( "Glyph width:  %ld\n", glyph->width );
     printf( "Glyph height: %ld\n", glyph->height );
@@ -457,7 +458,7 @@ int main( int argc, char **argv )
     // Generate the glyp at 512 points, compute distance field and scale it
     // back to 32 points
     // Just load another glyph if you want to see difference (draw render a '@')
-    glyph = load_glyph( "fonts/Vera.ttf", L'@', 512, 64, 0.1);
+    glyph = load_glyph( "fonts/Vera.ttf", "@", 512, 64, 0.1);
     vector_push_back( font->glyphs, &glyph );
 
     texture_atlas_upload( atlas );

--- a/demos/distance-field-3.c
+++ b/demos/distance-field-3.c
@@ -232,7 +232,7 @@ void display( GLFWwindow* window )
     GLuint handle = glGetUniformLocation( program, "texture" );
     glUniform1i( handle, 0);
 
-    texture_glyph_t * glyph = texture_font_get_glyph( font, L'@');
+    texture_glyph_t * glyph = texture_font_get_glyph( font, "@");
 
     float s0 = glyph->s0;
     float t0 = glyph->t0;

--- a/demos/distance-field.c
+++ b/demos/distance-field.c
@@ -279,9 +279,9 @@ int main( int argc, char **argv )
     unsigned char *map;
     texture_font_t * font;
     const char *filename = "fonts/Vera.ttf";
-    const wchar_t *cache = L" !\"#$%&'()*+,-./0123456789:;<=>?"
-                           L"@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
-                           L"`abcdefghijklmnopqrstuvwxyz{|}~";
+    const char * cache = " !\"#$%&'()*+,-./0123456789:;<=>?"
+                         "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
+                         "`abcdefghijklmnopqrstuvwxyz{|}~";
 
     atlas = texture_atlas_new( 512, 512, 1 );
     font = texture_font_new_from_file( atlas, 72, filename );

--- a/demos/embedded-font.c
+++ b/demos/embedded-font.c
@@ -34,23 +34,24 @@
 #include "opengl.h"
 #include "vec234.h"
 #include "vector.h"
+#include "utf8-utils.h"
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <wchar.h>
+#include <string.h>
 #include "vera-16.h"
 
 #include <GLFW/glfw3.h>
 
-void print_at( int pen_x, int pen_y, wchar_t *text )
+void print_at( int pen_x, int pen_y, char *text )
 {
     size_t i, j;
-    for( i=0; i<wcslen(text); ++i)
+    for( i=0; i < strlen(text); ++i)
     {
         texture_glyph_t *glyph = 0;
         for( j=0; j<font.glyphs_count; ++j)
         {
-            if( font.glyphs[j].charcode == text[i] )
+            if( font.glyphs[j].charcode == utf8_to_utf32( text + i ) )
             {
                 glyph = &font.glyphs[j];
                 break;
@@ -85,7 +86,7 @@ void display( GLFWwindow* window )
 {
     glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
     glColor4f(0,0,0,1);
-    print_at( 100, 100, L"Hello World !" );
+    print_at( 100, 100, "Hello World !" );
 
     glfwSwapBuffers( window );
 }

--- a/demos/font.c
+++ b/demos/font.c
@@ -121,7 +121,9 @@ void add_text( vertex_buffer_t * buffer, texture_font_t * font,
             float kerning =  0.0f;
             if( i > 0)
             {
-                kerning = texture_glyph_get_kerning( glyph, text[i-1] );
+                char * character = utf16_to_utf8( text[i-1] );
+                kerning = texture_glyph_get_kerning( glyph, character );
+                free( character );
             }
             pen->x += kerning;
             int x0  = (int)( pen->x + glyph->offset_x );

--- a/demos/font.c
+++ b/demos/font.c
@@ -42,6 +42,7 @@
 #include "mat4.h"
 #include "shader.h"
 #include "vertex-buffer.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -201,7 +202,9 @@ int main( int argc, char **argv )
         font = texture_font_new_from_file( atlas, i, filename );
         pen.x = 5;
         pen.y -= font->height;
-        texture_font_load_glyphs( font, text );
+        char* utext = str_utf16_to_utf8( text );
+        texture_font_load_glyphs( font, utext );
+        free( utext );
         add_text( buffer, font, text, &black, &pen );
         texture_font_delete( font );
     }

--- a/demos/font.c
+++ b/demos/font.c
@@ -113,7 +113,9 @@ void add_text( vertex_buffer_t * buffer, texture_font_t * font,
     float r = color->red, g = color->green, b = color->blue, a = color->alpha;
     for( i=0; i<wcslen(text); ++i )
     {
-        texture_glyph_t *glyph = texture_font_get_glyph( font, text[i] );
+        char * character = utf16_to_utf8( text[i] );
+        texture_glyph_t *glyph = texture_font_get_glyph( font, character );
+        free( character );
         if( glyph != NULL )
         {
             float kerning =  0.0f;

--- a/demos/font.c
+++ b/demos/font.c
@@ -36,13 +36,12 @@
  * ============================================================================
  */
 #include <stdio.h>
-#include <wchar.h>
+#include <string.h>
 
 #include "freetype-gl.h"
 #include "mat4.h"
 #include "shader.h"
 #include "vertex-buffer.h"
-#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -107,23 +106,19 @@ void keyboard( GLFWwindow* window, int key, int scancode, int action, int mods )
 
 // --------------------------------------------------------------- add_text ---
 void add_text( vertex_buffer_t * buffer, texture_font_t * font,
-               wchar_t * text, vec4 * color, vec2 * pen )
+               char * text, vec4 * color, vec2 * pen )
 {
     size_t i;
     float r = color->red, g = color->green, b = color->blue, a = color->alpha;
-    for( i=0; i<wcslen(text); ++i )
+    for( i = 0; i < strlen(text); ++i )
     {
-        char * character = utf16_to_utf8( text[i] );
-        texture_glyph_t *glyph = texture_font_get_glyph( font, character );
-        free( character );
+        texture_glyph_t *glyph = texture_font_get_glyph( font, text + i );
         if( glyph != NULL )
         {
             float kerning =  0.0f;
             if( i > 0)
             {
-                char * character = utf16_to_utf8( text[i-1] );
-                kerning = texture_glyph_get_kerning( glyph, character );
-                free( character );
+                kerning = texture_glyph_get_kerning( glyph, text + i - 1 );
             }
             pen->x += kerning;
             int x0  = (int)( pen->x + glyph->offset_x );
@@ -197,7 +192,7 @@ int main( int argc, char **argv )
     texture_font_t *font = 0;
     texture_atlas_t *atlas = texture_atlas_new( 512, 512, 1 );
     const char * filename = "fonts/Vera.ttf";
-    wchar_t *text = L"A Quick Brown Fox Jumps Over The Lazy Dog 0123456789";
+    char * text = "A Quick Brown Fox Jumps Over The Lazy Dog 0123456789";
     buffer = vertex_buffer_new( "vertex:3f,tex_coord:2f,color:4f" );
     vec2 pen = {{5,400}};
     vec4 black = {{0,0,0,1}};
@@ -206,9 +201,7 @@ int main( int argc, char **argv )
         font = texture_font_new_from_file( atlas, i, filename );
         pen.x = 5;
         pen.y -= font->height;
-        char* utext = str_utf16_to_utf8( text );
-        texture_font_load_glyphs( font, utext );
-        free( utext );
+        texture_font_load_glyphs( font, text );
         add_text( buffer, font, text, &black, &pen );
         texture_font_delete( font );
     }

--- a/demos/gamma.c
+++ b/demos/gamma.c
@@ -37,7 +37,6 @@
  */
 #include <stdarg.h>
 #include <stdio.h>
-#include <wchar.h>
 
 #include "freetype-gl.h"
 #include "vertex-buffer.h"
@@ -45,7 +44,6 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
-#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -186,13 +184,11 @@ int main( int argc, char **argv )
     pen.x = 32;
     pen.y = 508;
 
-    wchar_t *text = L"A Quick Brown Fox Jumps Over The Lazy Dog 0123456789\n";
+    char *text = "A Quick Brown Fox Jumps Over The Lazy Dog 0123456789\n";
     for( i=0; i < 14; ++i )
     {
         markup.gamma = 0.75 + 1.5*i*(1.0/14);
-        char * utext = str_utf16_to_utf8( text );
-        text_buffer_add_text( buffer, &pen, &markup, utext, 0 );
-        free( utext );
+        text_buffer_add_text( buffer, &pen, &markup, text, 0 );
     }
     pen.x = 32;
     pen.y = 252;
@@ -200,9 +196,7 @@ int main( int argc, char **argv )
     for( i=0; i < 14; ++i )
     {
         markup.gamma = 0.75 + 1.5*i*(1.0/14);
-        char * utext = str_utf16_to_utf8( text );
-        text_buffer_add_text( buffer, &pen, &markup, utext, 0 );
-        free( utext );
+        text_buffer_add_text( buffer, &pen, &markup, text, 0 );
     }
 
     background = vertex_buffer_new( "vertex:3f,color:4f" );

--- a/demos/gamma.c
+++ b/demos/gamma.c
@@ -45,6 +45,7 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -189,7 +190,9 @@ int main( int argc, char **argv )
     for( i=0; i < 14; ++i )
     {
         markup.gamma = 0.75 + 1.5*i*(1.0/14);
-        text_buffer_add_text( buffer, &pen, &markup, text, wcslen(text) );
+        char * utext = str_utf16_to_utf8( text );
+        text_buffer_add_text( buffer, &pen, &markup, utext, 0 );
+        free( utext );
     }
     pen.x = 32;
     pen.y = 252;
@@ -197,7 +200,9 @@ int main( int argc, char **argv )
     for( i=0; i < 14; ++i )
     {
         markup.gamma = 0.75 + 1.5*i*(1.0/14);
-        text_buffer_add_text( buffer, &pen, &markup, text, wcslen(text) );
+        char * utext = str_utf16_to_utf8( text );
+        text_buffer_add_text( buffer, &pen, &markup, utext, 0 );
+        free( utext );
     }
 
     background = vertex_buffer_new( "vertex:3f,color:4f" );

--- a/demos/glyph.c
+++ b/demos/glyph.c
@@ -31,7 +31,7 @@
  * policies, either expressed or implied, of Nicolas P. Rougier.
  * ========================================================================= */
 #include <stdio.h>
-#include <wchar.h>
+#include <string.h>
 
 #include "freetype-gl.h"
 
@@ -40,7 +40,6 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
-#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -131,23 +130,19 @@ void keyboard( GLFWwindow* window, int key, int scancode, int action, int mods )
 
 // --------------------------------------------------------------- add_text ---
 void add_text( vertex_buffer_t * buffer, texture_font_t * font,
-               wchar_t *  text, vec4 * color, vec2 * pen )
+               char *text, vec4 * color, vec2 * pen )
 {
     size_t i;
     float r = color->red, g = color->green, b = color->blue, a = color->alpha;
-    for( i=0; i<wcslen(text); ++i )
+    for( i = 0; i < strlen(text); ++i )
     {
-        char * character = utf16_to_utf8( text[i] );
-        texture_glyph_t *glyph = texture_font_get_glyph( font, character );
-        free( character );
+        texture_glyph_t *glyph = texture_font_get_glyph( font, text + i );
         if( glyph != NULL )
         {
             float kerning = 0.0f;
             if( i > 0)
             {
-                char * character = utf16_to_utf8( text[i-1] );
-                kerning = texture_glyph_get_kerning( glyph, character );
-                free( character );
+                kerning = texture_glyph_get_kerning( glyph, text + i - 1 );
             }
             pen->x += kerning;
             int x0  = (int)( pen->x + glyph->offset_x );
@@ -235,12 +230,12 @@ int main( int argc, char **argv )
     texture_glyph_t *glyph  = texture_font_get_glyph( big, "g" );
     origin.x = width/2  - glyph->offset_x - glyph->width/2;
     origin.y = height/2 - glyph->offset_y + glyph->height/2;
-    add_text( text_buffer, big, L"g", &black, &origin );
+    add_text( text_buffer, big, "g", &black, &origin );
 
     // title
     pen.x = 50;
     pen.y = 560;
-    add_text( text_buffer, title, L"Glyph metrics", &black, &pen );
+    add_text( text_buffer, title, "Glyph metrics", &black, &pen );
 
     point_t vertices[] =
         {   // Baseline
@@ -300,27 +295,27 @@ int main( int argc, char **argv )
 
     pen.x = width/2 - 48;
     pen.y = .2*height - 18;
-    add_text( text_buffer, small, L"advance_x", &blue, &pen );
+    add_text( text_buffer, small, "advance_x", &blue, &pen );
 
     pen.x = width/2 - 20;
     pen.y = .8*height + 3;
-    add_text( text_buffer, small, L"width", &blue, &pen );
+    add_text( text_buffer, small, "width", &blue, &pen );
 
     pen.x = width/2 - glyph->width/2 + 5;
     pen.y = .85*height-8;
-    add_text( text_buffer, small, L"offset_x", &blue, &pen );
+    add_text( text_buffer, small, "offset_x", &blue, &pen );
 
     pen.x = 0.2*width/2-30;
     pen.y = origin.y + glyph->offset_y - glyph->height/2;
-    add_text( text_buffer, small, L"height", &blue, &pen );
+    add_text( text_buffer, small, "height", &blue, &pen );
 
     pen.x = 0.8*width+3;
     pen.y = origin.y + glyph->offset_y/2 -6;
-    add_text( text_buffer, small, L"offset_y", &blue, &pen );
+    add_text( text_buffer, small, "offset_y", &blue, &pen );
 
     pen.x = width/2  - glyph->offset_x - glyph->width/2 - 58;
     pen.y = height/2 - glyph->offset_y + glyph->height/2 - 20;
-    add_text( text_buffer, small, L"Origin", &black, &pen );
+    add_text( text_buffer, small, "Origin", &black, &pen );
 
 
     GLuint i = 0;

--- a/demos/glyph.c
+++ b/demos/glyph.c
@@ -145,7 +145,9 @@ void add_text( vertex_buffer_t * buffer, texture_font_t * font,
             float kerning = 0.0f;
             if( i > 0)
             {
-                kerning = texture_glyph_get_kerning( glyph, text[i-1] );
+                char * character = utf16_to_utf8( text[i-1] );
+                kerning = texture_glyph_get_kerning( glyph, character );
+                free( character );
             }
             pen->x += kerning;
             int x0  = (int)( pen->x + glyph->offset_x );

--- a/demos/glyph.c
+++ b/demos/glyph.c
@@ -40,6 +40,7 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -136,7 +137,9 @@ void add_text( vertex_buffer_t * buffer, texture_font_t * font,
     float r = color->red, g = color->green, b = color->blue, a = color->alpha;
     for( i=0; i<wcslen(text); ++i )
     {
-        texture_glyph_t *glyph = texture_font_get_glyph( font, text[i] );
+        char * character = utf16_to_utf8( text[i] );
+        texture_glyph_t *glyph = texture_font_get_glyph( font, character );
+        free( character );
         if( glyph != NULL )
         {
             float kerning = 0.0f;
@@ -227,7 +230,7 @@ int main( int argc, char **argv )
 
     vec2 pen, origin;
 
-    texture_glyph_t *glyph  = texture_font_get_glyph( big, L'g' );
+    texture_glyph_t *glyph  = texture_font_get_glyph( big, "g" );
     origin.x = width/2  - glyph->offset_x - glyph->width/2;
     origin.y = height/2 - glyph->offset_y + glyph->height/2;
     add_text( text_buffer, big, L"g", &black, &origin );

--- a/demos/lcd.c
+++ b/demos/lcd.c
@@ -133,7 +133,9 @@ void add_text( vertex_buffer_t * buffer, texture_font_t * font,
             float kerning = 0.0f;
             if( i > 0)
             {
-                kerning = texture_glyph_get_kerning( glyph, text[i-1] );
+                char * character = utf16_to_utf8( text[i-1] );
+                kerning = texture_glyph_get_kerning( glyph, character );
+                free( character );
             }
             pen->x += kerning;
             int x0  = (int)( pen->x + glyph->offset_x );

--- a/demos/lcd.c
+++ b/demos/lcd.c
@@ -37,6 +37,7 @@
 #include "vertex-buffer.h"
 #include "shader.h"
 #include "mat4.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -218,7 +219,9 @@ int main( int argc, char **argv )
         font = texture_font_new_from_file( atlas, i, filename );
         pen.x = 0;
         pen.y -= font->height;
-        texture_font_load_glyphs( font, text );
+        char* utext = str_utf16_to_utf8( text );
+        texture_font_load_glyphs( font, utext );
+        free( utext );
         add_text( buffer, font, text, &color, &pen );
         texture_font_delete( font );
     }

--- a/demos/lcd.c
+++ b/demos/lcd.c
@@ -31,13 +31,12 @@
  * policies, either expressed or implied, of Nicolas P. Rougier.
  * ========================================================================= */
 #include <stdio.h>
-#include <wchar.h>
+#include <string.h>
 
 #include "freetype-gl.h"
 #include "vertex-buffer.h"
 #include "shader.h"
 #include "mat4.h"
-#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -119,23 +118,19 @@ void keyboard( GLFWwindow* window, int key, int scancode, int action, int mods )
 
 // --------------------------------------------------------------- add_text ---
 void add_text( vertex_buffer_t * buffer, texture_font_t * font,
-               wchar_t * text, vec4 * color, vec2 * pen )
+               char * text, vec4 * color, vec2 * pen )
 {
     size_t i;
     float r = color->red, g = color->green, b = color->blue, a = color->alpha;
-    for( i=0; i<wcslen(text); ++i )
+    for( i = 0; i < strlen(text); ++i )
     {
-        char * character = utf16_to_utf8( text[i] );
-        texture_glyph_t *glyph = texture_font_get_glyph( font, character );
-        free( character );
+        texture_glyph_t *glyph = texture_font_get_glyph( font, text + i );
         if( glyph != NULL )
         {
             float kerning = 0.0f;
             if( i > 0)
             {
-                char * character = utf16_to_utf8( text[i-1] );
-                kerning = texture_glyph_get_kerning( glyph, character );
-                free( character );
+                kerning = texture_glyph_get_kerning( glyph, text + i - 1 );
             }
             pen->x += kerning;
             int x0  = (int)( pen->x + glyph->offset_x );
@@ -213,7 +208,7 @@ int main( int argc, char **argv )
     texture_font_t *font = 0;
     atlas = texture_atlas_new( 512, 512, 3 );
     const char * filename = "fonts/Vera.ttf";
-    wchar_t *text = L"A Quick Brown Fox Jumps Over The Lazy Dog 0123456789";
+    char * text = "A Quick Brown Fox Jumps Over The Lazy Dog 0123456789";
     buffer = vertex_buffer_new( "vertex:3f,tex_coord:2f,color:4f,ashift:1f,agamma:1f" );
     vec2 pen = {{0,0}};
     vec4 color = {{0,0,0,1}};
@@ -223,9 +218,7 @@ int main( int argc, char **argv )
         font = texture_font_new_from_file( atlas, i, filename );
         pen.x = 0;
         pen.y -= font->height;
-        char* utext = str_utf16_to_utf8( text );
-        texture_font_load_glyphs( font, utext );
-        free( utext );
+        texture_font_load_glyphs( font, text );
         add_text( buffer, font, text, &color, &pen );
         texture_font_delete( font );
     }

--- a/demos/lcd.c
+++ b/demos/lcd.c
@@ -125,7 +125,9 @@ void add_text( vertex_buffer_t * buffer, texture_font_t * font,
     float r = color->red, g = color->green, b = color->blue, a = color->alpha;
     for( i=0; i<wcslen(text); ++i )
     {
-        texture_glyph_t *glyph = texture_font_get_glyph( font, text[i] );
+        char * character = utf16_to_utf8( text[i] );
+        texture_glyph_t *glyph = texture_font_get_glyph( font, character );
+        free( character );
         if( glyph != NULL )
         {
             float kerning = 0.0f;

--- a/demos/markup.c
+++ b/demos/markup.c
@@ -241,18 +241,18 @@ int main( int argc, char **argv )
 
     vec2 pen = {{20, 200}};
     text_buffer_printf( buffer, &pen,
-                        &underline, L"The",
-                        &normal,    L" Quick",
-                        &big,       L" brown ",
-                        &reverse,   L" fox \n",
-                        &italic,    L"jumps over ",
-                        &bold,      L"the lazy ",
-                        &normal,    L"dog.\n",
-                        &small,     L"Now is the time for all good men "
-                                    L"to come to the aid of the party.\n",
-                        &italic,    L"Ég get etið gler án þess að meiða mig.\n",
-                        &japanese,  L"私はガラスを食べられます。 それは私を傷つけません\n",
-                        &math,      L"ℕ ⊆ ℤ ⊂ ℚ ⊂ ℝ ⊂ ℂ",
+                        &underline, "The",
+                        &normal,    " Quick",
+                        &big,       " brown ",
+                        &reverse,   " fox \n",
+                        &italic,    "jumps over ",
+                        &bold,      "the lazy ",
+                        &normal,    "dog.\n",
+                        &small,     "Now is the time for all good men "
+                                    "to come to the aid of the party.\n",
+                        &italic,    "Ég get etið gler án þess að meiða mig.\n",
+                        &japanese,  "私はガラスを食べられます。 それは私を傷つけません\n",
+                        &math,      "ℕ ⊆ ℤ ⊂ ℚ ⊂ ℝ ⊂ ℂ",
                         NULL );
     mat4_set_identity( &projection );
     mat4_set_identity( &model );

--- a/demos/outline.c
+++ b/demos/outline.c
@@ -144,7 +144,9 @@ void add_text( vertex_buffer_t * buffer, vec2 * pen, ... )
                 float kerning = 0.0f;
                 if( i > 0)
                 {
-                    kerning = texture_glyph_get_kerning( glyph, text[i-1] );
+                    char * character = utf16_to_utf8( text[i-1] );
+                    kerning = texture_glyph_get_kerning( glyph, character );
+                    free( character );
                 }
                 pen->x += kerning;
 

--- a/demos/outline.c
+++ b/demos/outline.c
@@ -39,6 +39,7 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -134,7 +135,9 @@ void add_text( vertex_buffer_t * buffer, vec2 * pen, ... )
 
         for( i=0; i<wcslen(text); ++i )
         {
-            texture_glyph_t *glyph = texture_font_get_glyph( font, text[i] );
+            char * character = utf16_to_utf8( text[i] );
+            texture_glyph_t *glyph = texture_font_get_glyph( font, character );
+            free( character );
 
             if( glyph != NULL )
             {

--- a/demos/outline.c
+++ b/demos/outline.c
@@ -32,14 +32,13 @@
  * ========================================================================= */
 #include <stdarg.h>
 #include <stdio.h>
-#include <wchar.h>
+#include <string.h>
 
 #include "freetype-gl.h"
 #include "vertex-buffer.h"
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
-#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -114,7 +113,7 @@ void keyboard( GLFWwindow* window, int key, int scancode, int action, int mods )
 void add_text( vertex_buffer_t * buffer, vec2 * pen, ... )
 {
     markup_t *markup;
-    wchar_t *text;
+    char *text;
     va_list args;
     va_start ( args, pen );
 
@@ -124,7 +123,7 @@ void add_text( vertex_buffer_t * buffer, vec2 * pen, ... )
         {
             break;
         }
-        text = va_arg( args, wchar_t * );
+        text = va_arg( args, char * );
 
         size_t i;
         texture_font_t * font = markup->font;
@@ -133,20 +132,16 @@ void add_text( vertex_buffer_t * buffer, vec2 * pen, ... )
         float b = markup->foreground_color.blue;
         float a = markup->foreground_color.alpha;
 
-        for( i=0; i<wcslen(text); ++i )
+        for( i = 0; i < strlen(text); ++i )
         {
-            char * character = utf16_to_utf8( text[i] );
-            texture_glyph_t *glyph = texture_font_get_glyph( font, character );
-            free( character );
+            texture_glyph_t *glyph = texture_font_get_glyph( font, text + i );
 
             if( glyph != NULL )
             {
                 float kerning = 0.0f;
                 if( i > 0)
                 {
-                    char * character = utf16_to_utf8( text[i-1] );
-                    kerning = texture_glyph_get_kerning( glyph, character );
-                    free( character );
+                    kerning = texture_glyph_get_kerning( glyph, text + i - 1 );
                 }
                 pen->x += kerning;
 
@@ -259,7 +254,7 @@ int main( int argc, char **argv )
     for( i=0; i< 10; ++i)
     {
         markup.font->outline_thickness = 2*((i+1)/10.0);
-        add_text( buffer, &pen, &markup, L"g", NULL );
+        add_text( buffer, &pen, &markup, "g", NULL );
     }
 
     pen.x = 40;
@@ -268,7 +263,7 @@ int main( int argc, char **argv )
     for( i=0; i< 10; ++i)
     {
         markup.font->outline_thickness = 2*((i+1)/10.0);
-        add_text( buffer, &pen, &markup, L"g", NULL );
+        add_text( buffer, &pen, &markup, "g", NULL );
     }
 
     pen.x = 40;
@@ -277,7 +272,7 @@ int main( int argc, char **argv )
     for( i=0; i< 10; ++i)
     {
         markup.font->outline_thickness = 1*((i+1)/10.0);
-        add_text( buffer, &pen, &markup, L"g", NULL );
+        add_text( buffer, &pen, &markup, "g", NULL );
     }
     shader = shader_load("shaders/v3f-t2f-c4f.vert",
                          "shaders/v3f-t2f-c4f.frag");

--- a/demos/subpixel.c
+++ b/demos/subpixel.c
@@ -44,6 +44,7 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -205,7 +206,9 @@ int main( int argc, char **argv )
     wchar_t *text = L"| A Quick Brown Fox Jumps Over The Lazy Dog\n";
     for( i=0; i < 30; ++i)
     {
-        text_buffer_add_text( text_buffer, &pen, &markup, text, wcslen(text) );
+        char * utext = str_utf16_to_utf8( text );
+        text_buffer_add_text( text_buffer, &pen, &markup, utext, 0 );
+        free( utext );
         pen.x += i*0.1;
     }
 

--- a/demos/subpixel.c
+++ b/demos/subpixel.c
@@ -35,7 +35,6 @@
 #include FT_CONFIG_OPTIONS_H
 
 #include <stdio.h>
-#include <wchar.h>
 
 #include "freetype-gl.h"
 
@@ -44,7 +43,6 @@
 #include "markup.h"
 #include "shader.h"
 #include "mat4.h"
-#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -203,12 +201,10 @@ int main( int argc, char **argv )
 
     size_t i;
     vec2 pen = {{20, 320}};
-    wchar_t *text = L"| A Quick Brown Fox Jumps Over The Lazy Dog\n";
+    char *text = "| A Quick Brown Fox Jumps Over The Lazy Dog\n";
     for( i=0; i < 30; ++i)
     {
-        char * utext = str_utf16_to_utf8( text );
-        text_buffer_add_text( text_buffer, &pen, &markup, utext, 0 );
-        free( utext );
+        text_buffer_add_text( text_buffer, &pen, &markup, text, 0 );
         pen.x += i*0.1;
     }
 

--- a/demos/texture.c
+++ b/demos/texture.c
@@ -42,6 +42,7 @@
 #include "mat4.h"
 #include "shader.h"
 #include "vertex-buffer.h"
+#include "utf8-utils.h"
 
 #include <GLFW/glfw3.h>
 
@@ -151,7 +152,9 @@ int main( int argc, char **argv )
     for( i=minsize; i < maxsize; ++i )
     {
         texture_font_t * font = texture_font_new_from_file( atlas, i, filename );
-        missed += texture_font_load_glyphs( font, cache );
+        char* ucache = str_utf16_to_utf8( cache );
+        missed += texture_font_load_glyphs( font, ucache );
+        free( ucache );
         texture_font_delete( font );
     }
 

--- a/demos/texture.c
+++ b/demos/texture.c
@@ -36,7 +36,7 @@
  * ============================================================================
  */
 #include <stdio.h>
-#include <wchar.h>
+#include <string.h>
 
 #include "freetype-gl.h"
 #include "mat4.h"
@@ -142,9 +142,9 @@ int main( int argc, char **argv )
 #endif
     texture_atlas_t * atlas = texture_atlas_new( 512, 512, 1 );
     const char *filename = "fonts/Vera.ttf";
-    const wchar_t *cache = L" !\"#$%&'()*+,-./0123456789:;<=>?"
-                           L"@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
-                           L"`abcdefghijklmnopqrstuvwxyz{|}~";
+    const char * cache = " !\"#$%&'()*+,-./0123456789:;<=>?"
+                         "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
+                         "`abcdefghijklmnopqrstuvwxyz{|}~";
     size_t minsize = 8, maxsize = 27;
     size_t count = maxsize - minsize;
     size_t i, missed = 0;
@@ -152,18 +152,16 @@ int main( int argc, char **argv )
     for( i=minsize; i < maxsize; ++i )
     {
         texture_font_t * font = texture_font_new_from_file( atlas, i, filename );
-        char* ucache = str_utf16_to_utf8( cache );
-        missed += texture_font_load_glyphs( font, ucache );
-        free( ucache );
+        missed += texture_font_load_glyphs( font, cache );
         texture_font_delete( font );
     }
 
     printf( "Matched font               : %s\n", filename );
     printf( "Number of fonts            : %ld\n", count );
-    printf( "Number of glyphs per font  : %ld\n", wcslen(cache) );
+    printf( "Number of glyphs per font  : %ld\n", utf8_strlen(cache) );
     printf( "Number of missed glyphs    : %ld\n", missed );
     printf( "Total number of glyphs     : %ld/%ld\n",
-            wcslen(cache)*count - missed, wcslen(cache)*count );
+            utf8_strlen(cache)*count - missed, utf8_strlen(cache)*count );
     printf( "Texture size               : %ldx%ld\n", atlas->width, atlas->height );
     printf( "Texture occupancy          : %.2f%%\n",
             100.0*atlas->used/(float)(atlas->width*atlas->height) );

--- a/doc/documentation.h
+++ b/doc/documentation.h
@@ -29,7 +29,7 @@ vertex buffer and a single texture where necessary glyphs are tighly packed.
    ...
 
    // Text to be printed
-   wchar_t *text = L"A Quick Brown Fox Jumps Over The Lazy Dog 0123456789";
+   char *text = "A Quick Brown Fox Jumps Over The Lazy Dog 0123456789";
 
    // Texture atlas to store individual glyphs
    texture_atlas_t *atlas = texture_atlas_new( 512, 512, 1 );

--- a/font-manager.c
+++ b/font-manager.c
@@ -42,6 +42,7 @@
 #include <string.h>
 #include <wchar.h>
 #include "font-manager.h"
+#include "utf8-utils.h"
 
 
 // ------------------------------------------------------------ file_exists ---
@@ -149,8 +150,10 @@ font_manager_get_from_filename( font_manager_t *self,
     font = texture_font_new_from_file( self->atlas, size, filename );
     if( font )
     {
+        char* cache = str_utf16_to_utf8( self->cache );
         vector_push_back( self->fonts, &font );
-        texture_font_load_glyphs( font, self->cache );
+        texture_font_load_glyphs( font, cache );
+        free(cache);
         return font;
     }
     fprintf( stderr, "Unable to load \"%s\" (size=%.1f)\n", filename, size );

--- a/font-manager.c
+++ b/font-manager.c
@@ -40,9 +40,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <wchar.h>
 #include "font-manager.h"
-#include "utf8-utils.h"
 
 
 // ------------------------------------------------------------ file_exists ---
@@ -74,7 +72,7 @@ font_manager_new( size_t width, size_t height, size_t depth )
     }
     self->atlas = atlas;
     self->fonts = vector_new( sizeof(texture_font_t *) );
-    self->cache = wcsdup( L" " );
+    self->cache = strdup( " " );
     return self;
 }
 
@@ -150,10 +148,8 @@ font_manager_get_from_filename( font_manager_t *self,
     font = texture_font_new_from_file( self->atlas, size, filename );
     if( font )
     {
-        char* cache = str_utf16_to_utf8( self->cache );
         vector_push_back( self->fonts, &font );
-        texture_font_load_glyphs( font, cache );
-        free(cache);
+        texture_font_load_glyphs( font, self->cache );
         return font;
     }
     fprintf( stderr, "Unable to load \"%s\" (size=%.1f)\n", filename, size );

--- a/font-manager.h
+++ b/font-manager.h
@@ -89,7 +89,7 @@ typedef struct font_manager_t {
     /**
      * Default glyphs to be loaded when loading a new font.
      */
-    wchar_t * cache;
+    char * cache;
 
 } font_manager_t;
 

--- a/makefont.c
+++ b/makefont.c
@@ -35,6 +35,7 @@
 #include "vec234.h"
 #include "vector.h"
 #include "freetype-gl.h"
+#include "utf8-utils.h"
 
 #include <errno.h>
 #include <stdio.h>
@@ -280,7 +281,9 @@ int main( int argc, char **argv )
 
     glfwMakeContextCurrent( window );
 
-    size_t missed = texture_font_load_glyphs( font, font_cache );
+    char * ucache = str_utf16_to_utf8( font_cache );
+    size_t missed = texture_font_load_glyphs( font, ucache );
+    free( ucache );
 
     wprintf( L"Font filename              : %s\n", font_filename );
     wprintf( L"Font size                  : %.1f\n", font_size );

--- a/makefont.c
+++ b/makefont.c
@@ -359,6 +359,7 @@ int main( int argc, char **argv )
     // ----------------------
     fwprintf( file,
         L"#include <stddef.h>\n"
+        L"#include <stdint.h>\n"
         L"#ifdef __cplusplus\n"
         L"extern \"C\" {\n"
         L"#endif\n"
@@ -372,7 +373,7 @@ int main( int argc, char **argv )
     fwprintf( file,
         L"typedef struct\n"
         L"{\n"
-        L"    wchar_t charcode;\n"
+        L"    uint32_t charcode;\n"
         L"    int width, height;\n"
         L"    int offset_x, offset_y;\n"
         L"    float advance_x, advance_y;\n"
@@ -479,21 +480,7 @@ int main( int argc, char **argv )
 
 
         // TextureFont
-        if( (glyph->charcode == L'\'' ) || (glyph->charcode == L'\\' ) )
-        {
-            fwprintf( file, L"  {L'\\%lc', ", glyph->charcode );
-            //wprintf( L"  {L'\\%lc', ", glyph->charcode );
-        }
-        else if( glyph->charcode == (wchar_t)(-1) )
-        {
-            fwprintf( file, L"  {L'\\0', " );
-            //wprintf( L"  {L'\\0', " );
-        }
-        else
-        {
-            fwprintf( file, L"  {L'%lc', ", glyph->charcode );
-            //wprintf( L"  {L'%lc', ", glyph->charcode );
-        }
+        fwprintf( file, L"  {%zu, ", glyph->charcode );
         fwprintf( file, L"%d, %d, ", glyph->width, glyph->height );
         fwprintf( file, L"%d, %d, ", glyph->offset_x, glyph->offset_y );
         fwprintf( file, L"%ff, %ff, ", glyph->advance_x, glyph->advance_y );

--- a/makefont.c
+++ b/makefont.c
@@ -35,12 +35,10 @@
 #include "vec234.h"
 #include "vector.h"
 #include "freetype-gl.h"
-#include "utf8-utils.h"
 
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
-#include <wchar.h>
 
 #include <GLFW/glfw3.h>
 
@@ -67,10 +65,10 @@ int main( int argc, char **argv )
     size_t i, j;
     int arg;
 
-    wchar_t * font_cache =
-        L" !\"#$%&'()*+,-./0123456789:;<=>?"
-        L"@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
-        L"`abcdefghijklmnopqrstuvwxyz{|}~";
+    char * font_cache =
+        " !\"#$%&'()*+,-./0123456789:;<=>?"
+        "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
+        "`abcdefghijklmnopqrstuvwxyz{|}~";
 
     float  font_size   = 0.0;
     const char * font_filename   = NULL;
@@ -281,22 +279,25 @@ int main( int argc, char **argv )
 
     glfwMakeContextCurrent( window );
 
-    char * ucache = str_utf16_to_utf8( font_cache );
-    size_t missed = texture_font_load_glyphs( font, ucache );
-    free( ucache );
+    size_t missed = texture_font_load_glyphs( font, font_cache );
 
-    wprintf( L"Font filename              : %s\n", font_filename );
-    wprintf( L"Font size                  : %.1f\n", font_size );
-    wprintf( L"Number of glyphs           : %ld\n", wcslen(font_cache) );
-    wprintf( L"Number of missed glyphs    : %ld\n", missed );
-    wprintf( L"Texture size               : %ldx%ldx%ld\n",
-             atlas->width, atlas->height, atlas->depth );
-    wprintf( L"Texture occupancy          : %.2f%%\n",
-            100.0*atlas->used/(float)(atlas->width*atlas->height) );
-    wprintf( L"\n" );
-    wprintf( L"Header filename            : %s\n", header_filename );
-    wprintf( L"Variable name              : %s\n", variable_name );
-
+    printf( "Font filename           : %s\n"
+            "Font size               : %.1f\n"
+            "Number of glyphs        : %ld\n"
+            "Number of missed glyphs : %ld\n"
+            "Texture size            : %ldx%ldx%ld\n"
+            "Texture occupancy       : %.2f%%\n"
+            "\n"
+            "Header filename         : %s\n"
+            "Variable name           : %s\n",
+            font_filename,
+            font_size,
+            strlen(font_cache),
+            missed,
+            atlas->width, atlas->height, atlas->depth,
+            100.0 * atlas->used / (float)(atlas->width * atlas->height),
+            header_filename,
+            variable_name );
 
     size_t texture_size = atlas->width * atlas->height *atlas->depth;
     size_t glyph_count = font->glyphs->size;
@@ -318,121 +319,121 @@ int main( int argc, char **argv )
     // -------------
     // Header
     // -------------
-    fwprintf( file,
-        L"/* ============================================================================\n"
-        L" * Freetype GL - A C OpenGL Freetype engine\n"
-        L" * Platform:    Any\n"
-        L" * WWW:         https://github.com/rougier/freetype-gl\n"
-        L" * ----------------------------------------------------------------------------\n"
-        L" * Copyright 2011,2012 Nicolas P. Rougier. All rights reserved.\n"
-        L" *\n"
-        L" * Redistribution and use in source and binary forms, with or without\n"
-        L" * modification, are permitted provided that the following conditions are met:\n"
-        L" *\n"
-        L" *  1. Redistributions of source code must retain the above copyright notice,\n"
-        L" *     this list of conditions and the following disclaimer.\n"
-        L" *\n"
-        L" *  2. Redistributions in binary form must reproduce the above copyright\n"
-        L" *     notice, this list of conditions and the following disclaimer in the\n"
-        L" *     documentation and/or other materials provided with the distribution.\n"
-        L" *\n"
-        L" * THIS SOFTWARE IS PROVIDED BY NICOLAS P. ROUGIER ''AS IS'' AND ANY EXPRESS OR\n"
-        L" * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF\n"
-        L" * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO\n"
-        L" * EVENT SHALL NICOLAS P. ROUGIER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,\n"
-        L" * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES\n"
-        L" * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;\n"
-        L" * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND\n"
-        L" * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n"
-        L" * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n"
-        L" * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n"
-        L" *\n"
-        L" * The views and conclusions contained in the software and documentation are\n"
-        L" * those of the authors and should not be interpreted as representing official\n"
-        L" * policies, either expressed or implied, of Nicolas P. Rougier.\n"
-        L" * ===============================================================================\n"
-        L" */\n");
+    fprintf( file,
+        "/* ============================================================================\n"
+        " * Freetype GL - A C OpenGL Freetype engine\n"
+        " * Platform:    Any\n"
+        " * WWW:         https://github.com/rougier/freetype-gl\n"
+        " * ----------------------------------------------------------------------------\n"
+        " * Copyright 2011,2012 Nicolas P. Rougier. All rights reserved.\n"
+        " *\n"
+        " * Redistribution and use in source and binary forms, with or without\n"
+        " * modification, are permitted provided that the following conditions are met:\n"
+        " *\n"
+        " *  1. Redistributions of source code must retain the above copyright notice,\n"
+        " *     this list of conditions and the following disclaimer.\n"
+        " *\n"
+        " *  2. Redistributions in binary form must reproduce the above copyright\n"
+        " *     notice, this list of conditions and the following disclaimer in the\n"
+        " *     documentation and/or other materials provided with the distribution.\n"
+        " *\n"
+        " * THIS SOFTWARE IS PROVIDED BY NICOLAS P. ROUGIER ''AS IS'' AND ANY EXPRESS OR\n"
+        " * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF\n"
+        " * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO\n"
+        " * EVENT SHALL NICOLAS P. ROUGIER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,\n"
+        " * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES\n"
+        " * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;\n"
+        " * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND\n"
+        " * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n"
+        " * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n"
+        " * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n"
+        " *\n"
+        " * The views and conclusions contained in the software and documentation are\n"
+        " * those of the authors and should not be interpreted as representing official\n"
+        " * policies, either expressed or implied, of Nicolas P. Rougier.\n"
+        " * ============================================================================\n"
+        " */\n");
 
 
     // ----------------------
     // Structure declarations
     // ----------------------
-    fwprintf( file,
-        L"#include <stddef.h>\n"
-        L"#include <stdint.h>\n"
-        L"#ifdef __cplusplus\n"
-        L"extern \"C\" {\n"
-        L"#endif\n"
-        L"\n"
-        L"typedef struct\n"
-        L"{\n"
-        L"    uint32_t charcode;\n"
-        L"    float kerning;\n"
-        L"} kerning_t;\n\n" );
+    fprintf( file,
+        "#include <stddef.h>\n"
+        "#include <stdint.h>\n"
+        "#ifdef __cplusplus\n"
+        "extern \"C\" {\n"
+        "#endif\n"
+        "\n"
+        "typedef struct\n"
+        "{\n"
+        "    uint32_t charcode;\n"
+        "    float kerning;\n"
+        "} kerning_t;\n\n" );
 
-    fwprintf( file,
-        L"typedef struct\n"
-        L"{\n"
-        L"    uint32_t charcode;\n"
-        L"    int width, height;\n"
-        L"    int offset_x, offset_y;\n"
-        L"    float advance_x, advance_y;\n"
-        L"    float s0, t0, s1, t1;\n"
-        L"    size_t kerning_count;\n"
-        L"    kerning_t kerning[%d];\n"
-        L"} texture_glyph_t;\n\n", max_kerning_count );
+    fprintf( file,
+        "typedef struct\n"
+        "{\n"
+        "    uint32_t charcode;\n"
+        "    int width, height;\n"
+        "    int offset_x, offset_y;\n"
+        "    float advance_x, advance_y;\n"
+        "    float s0, t0, s1, t1;\n"
+        "    size_t kerning_count;\n"
+        "    kerning_t kerning[%d];\n"
+        "} texture_glyph_t;\n\n", max_kerning_count );
 
-    fwprintf( file,
-        L"typedef struct\n"
-        L"{\n"
-        L"    size_t tex_width;\n"
-        L"    size_t tex_height;\n"
-        L"    size_t tex_depth;\n"
-        L"    char tex_data[%d];\n"
-        L"    float size;\n"
-        L"    float height;\n"
-        L"    float linegap;\n"
-        L"    float ascender;\n"
-        L"    float descender;\n"
-        L"    size_t glyphs_count;\n"
-        L"    texture_glyph_t glyphs[%d];\n"
-        L"} texture_font_t;\n\n", texture_size, glyph_count );
+    fprintf( file,
+        "typedef struct\n"
+        "{\n"
+        "    size_t tex_width;\n"
+        "    size_t tex_height;\n"
+        "    size_t tex_depth;\n"
+        "    char tex_data[%d];\n"
+        "    float size;\n"
+        "    float height;\n"
+        "    float linegap;\n"
+        "    float ascender;\n"
+        "    float descender;\n"
+        "    size_t glyphs_count;\n"
+        "    texture_glyph_t glyphs[%d];\n"
+        "} texture_font_t;\n\n", texture_size, glyph_count );
 
 
 
-    fwprintf( file, L"texture_font_t %s = {\n", variable_name );
+    fprintf( file, "texture_font_t %s = {\n", variable_name );
 
 
     // ------------
     // Texture data
     // ------------
-    fwprintf( file, L" %d, %d, %d, \n", atlas->width, atlas->height, atlas->depth );
-    fwprintf( file, L" {" );
+    fprintf( file, " %d, %d, %d, \n", atlas->width, atlas->height, atlas->depth );
+    fprintf( file, " {" );
     for( i=0; i < texture_size; i+= 32 )
     {
         for( j=0; j < 32 && (j+i) < texture_size ; ++ j)
         {
             if( (j+i) < (texture_size-1) )
             {
-                fwprintf( file, L"%d,", atlas->data[i+j] );
+                fprintf( file, "%d,", atlas->data[i+j] );
             }
             else
             {
-                fwprintf( file, L"%d", atlas->data[i+j] );
+                fprintf( file, "%d", atlas->data[i+j] );
             }
         }
         if( (j+i) < texture_size )
         {
-            fwprintf( file, L"\n  " );
+            fprintf( file, "\n  " );
         }
     }
-    fwprintf( file, L"}, \n" );
+    fprintf( file, "}, \n" );
 
 
     // -------------------
     // Texture information
     // -------------------
-    fwprintf( file, L" %ff, %ff, %ff, %ff, %ff, %d, \n",
+    fprintf( file, " %ff, %ff, %ff, %ff, %ff, %d, \n",
              font->size, font->height,
              font->linegap,font->ascender, font->descender,
              glyph_count );
@@ -440,71 +441,71 @@ int main( int argc, char **argv )
     // --------------
     // Texture glyphs
     // --------------
-    fwprintf( file, L" {\n" );
+    fprintf( file, " {\n" );
     for( i=0; i < glyph_count; ++i )
     {
         texture_glyph_t * glyph = *(texture_glyph_t **) vector_get( font->glyphs, i );
 
 /*
         // Debugging information
-        wprintf( L"glyph : '%lc'\n",
+        printf( "glyph : '%lc'\n",
                  glyph->charcode );
-        wprintf( L"  size       : %dx%d\n",
+        printf( "  size       : %dx%d\n",
                  glyph->width, glyph->height );
-        wprintf( L"  offset     : %+d%+d\n",
+        printf( "  offset     : %+d%+d\n",
                  glyph->offset_x, glyph->offset_y );
-        wprintf( L"  advance    : %ff, %ff\n",
+        printf( "  advance    : %ff, %ff\n",
                  glyph->advance_x, glyph->advance_y );
-        wprintf( L"  tex coords.: %ff, %ff, %ff, %ff\n",
+        printf( "  tex coords.: %ff, %ff, %ff, %ff\n",
                  glyph->u0, glyph->v0, glyph->u1, glyph->v1 );
 
-        wprintf( L"  kerning    : " );
+        printf( "  kerning    : " );
         if( glyph->kerning_count )
         {
             for( j=0; j < glyph->kerning_count; ++j )
             {
-                wprintf( L"('%lc', %ff)",
+                printf( "('%lc', %ff)",
                          glyph->kerning[j].charcode, glyph->kerning[j].kerning );
                 if( j < (glyph->kerning_count-1) )
                 {
-                    wprintf( L", " );
+                    printf( ", " );
                 }
             }
         }
         else
         {
-            wprintf( L"None" );
+            printf( "None" );
         }
-        wprintf( L"\n\n" );
+        printf( "\n\n" );
 */
 
 
         // TextureFont
-        fwprintf( file, L"  {%zu, ", glyph->charcode );
-        fwprintf( file, L"%d, %d, ", glyph->width, glyph->height );
-        fwprintf( file, L"%d, %d, ", glyph->offset_x, glyph->offset_y );
-        fwprintf( file, L"%ff, %ff, ", glyph->advance_x, glyph->advance_y );
-        fwprintf( file, L"%ff, %ff, %ff, %ff, ", glyph->s0, glyph->t0, glyph->s1, glyph->t1 );
-        fwprintf( file, L"%d, ", vector_size(glyph->kerning) );
-        fwprintf( file, L"{ " );
+        fprintf( file, "  {%zu, ", glyph->charcode );
+        fprintf( file, "%d, %d, ", glyph->width, glyph->height );
+        fprintf( file, "%d, %d, ", glyph->offset_x, glyph->offset_y );
+        fprintf( file, "%ff, %ff, ", glyph->advance_x, glyph->advance_y );
+        fprintf( file, "%ff, %ff, %ff, %ff, ", glyph->s0, glyph->t0, glyph->s1, glyph->t1 );
+        fprintf( file, "%d, ", vector_size(glyph->kerning) );
+        fprintf( file, "{ " );
         for( j=0; j < vector_size(glyph->kerning); ++j )
         {
             kerning_t *kerning = (kerning_t *) vector_get( glyph->kerning, j);
 
-            fwprintf( file, L"{%zu, %ff}", kerning->charcode, kerning->kerning );
+            fprintf( file, "{%zu, %ff}", kerning->charcode, kerning->kerning );
             if( j < (vector_size(glyph->kerning)-1))
             {
-                fwprintf( file, L", " );
+                fprintf( file, ", " );
             }
         }
-        fwprintf( file, L"} },\n" );
+        fprintf( file, "} },\n" );
     }
-    fwprintf( file, L" }\n};\n" );
+    fprintf( file, " }\n};\n" );
 
-    fwprintf( file,
-        L"#ifdef __cplusplus\n"
-        L"}\n"
-        L"#endif\n" );
+    fprintf( file,
+        "#ifdef __cplusplus\n"
+        "}\n"
+        "#endif\n" );
 
     glfwDestroyWindow( window );
     glfwTerminate( );

--- a/makefont.c
+++ b/makefont.c
@@ -366,7 +366,7 @@ int main( int argc, char **argv )
         L"\n"
         L"typedef struct\n"
         L"{\n"
-        L"    wchar_t charcode;\n"
+        L"    uint32_t charcode;\n"
         L"    float kerning;\n"
         L"} kerning_t;\n\n" );
 
@@ -490,16 +490,8 @@ int main( int argc, char **argv )
         for( j=0; j < vector_size(glyph->kerning); ++j )
         {
             kerning_t *kerning = (kerning_t *) vector_get( glyph->kerning, j);
-            wchar_t charcode = kerning->charcode;
 
-            if( (charcode == L'\'' ) || (charcode == L'\\') )
-            {
-                fwprintf( file, L"{L'\\%lc', %ff}", charcode, kerning->kerning );
-            }
-            else if( (charcode != (wchar_t)(-1) ) )
-            {
-                fwprintf( file, L"{L'%lc', %ff}", charcode, kerning->kerning );
-            }
+            fwprintf( file, L"{%zu, %ff}", kerning->charcode, kerning->kerning );
             if( j < (vector_size(glyph->kerning)-1))
             {
                 fwprintf( file, L", " );

--- a/text-buffer.c
+++ b/text-buffer.c
@@ -38,7 +38,7 @@
 #include <assert.h>
 #include "opengl.h"
 #include "text-buffer.h"
-
+#include "utf8-utils.h"
 
 #define SET_GLYPH_VERTEX(value,x0,y0,z0,s0,t0,r,g,b,a,sh,gm) { \
 	glyph_vertex_t *gv=&value;                                 \
@@ -288,8 +288,10 @@ text_buffer_add_wchar( text_buffer_t * self,
         self->line_descender = markup->font->descender;
     }
 
-    glyph = texture_font_get_glyph( font, current );
-    black = texture_font_get_glyph( font, -1 );
+    char * cur_buffer = utf16_to_utf8( current );
+    glyph = texture_font_get_glyph( font, cur_buffer );
+    free( cur_buffer );
+    black = texture_font_get_glyph( font, NULL );
 
     if( glyph == NULL )
     {

--- a/text-buffer.c
+++ b/text-buffer.c
@@ -300,7 +300,9 @@ text_buffer_add_wchar( text_buffer_t * self,
 
     if( previous && markup->font->kerning )
     {
-        kerning = texture_glyph_get_kerning( glyph, previous );
+        char * character = utf16_to_utf8( previous );
+        kerning = texture_glyph_get_kerning( glyph, character );
+        free( character );
     }
     pen->x += kerning;
 

--- a/text-buffer.c
+++ b/text-buffer.c
@@ -31,7 +31,6 @@
  * policies, either expressed or implied, of Nicolas P. Rougier.
  * ============================================================================
  */
-#include <wchar.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -163,7 +162,7 @@ void
 text_buffer_printf( text_buffer_t * self, vec2 *pen, ... )
 {
     markup_t *markup;
-    wchar_t *text;
+    char *text;
     va_list args;
 
     if( vertex_buffer_size( self->buffer ) == 0 )
@@ -178,10 +177,8 @@ text_buffer_printf( text_buffer_t * self, vec2 *pen, ... )
         {
             return;
         }
-        text = va_arg( args, wchar_t * );
-        char * utext = str_utf16_to_utf8( text );
-        text_buffer_add_text( self, pen, markup, utext, 0 );
-        free( utext );
+        text = va_arg( args, char * );
+        text_buffer_add_text( self, pen, markup, text, 0 );
     } while( markup != 0 );
     va_end ( args );
 }

--- a/text-buffer.h
+++ b/text-buffer.h
@@ -265,7 +265,7 @@ typedef struct glyph_vertex_t {
   *
   * @param self a text buffer
   * @param pen  position of text start
-  * @param ...  a series of markup_t *, wchar_t * ended by NULL
+  * @param ...  a series of markup_t *, char * ended by NULL
   *
   */
   void

--- a/text-buffer.h
+++ b/text-buffer.h
@@ -296,9 +296,9 @@ typedef struct glyph_vertex_t {
   * @param previous previous character (if any)
   */
   void
-  text_buffer_add_wchar( text_buffer_t * self,
-                         vec2 * pen, markup_t * markup,
-                         wchar_t current, wchar_t previous );
+  text_buffer_add_char( text_buffer_t * self,
+                        vec2 * pen, markup_t * markup,
+                        const char * current, const char * previous );
 
 /**
   * Clear text buffer

--- a/text-buffer.h
+++ b/text-buffer.h
@@ -284,7 +284,7 @@ typedef struct glyph_vertex_t {
   void
   text_buffer_add_text( text_buffer_t * self,
                         vec2 * pen, markup_t * markup,
-                        const wchar_t * text, size_t length );
+                        const char * text, size_t length );
 
  /**
   * Add a char to the text buffer

--- a/texture-font.c
+++ b/texture-font.c
@@ -161,6 +161,7 @@ texture_glyph_new(void)
         return NULL;
     }
 
+    self->charcode  = -1;
     self->id        = 0;
     self->width     = 0;
     self->height    = 0;
@@ -625,7 +626,7 @@ texture_font_load_glyphs( texture_font_t * self,
                                   ft_bitmap.buffer, ft_bitmap.pitch );
 
         glyph = texture_glyph_new( );
-        glyph->charcode = utf8_to_utf16(charcodes + i);
+        glyph->charcode = utf8_to_utf32( charcodes + i );
         glyph->width    = w;
         glyph->height   = h;
         glyph->outline_type = self->outline_type;
@@ -693,7 +694,7 @@ texture_font_get_glyph( texture_font_t * self,
             return NULL;
         }
         texture_atlas_set_region( self->atlas, region.x, region.y, 4, 4, data, 0 );
-        glyph->charcode = (wchar_t)(-1);
+        glyph->charcode = -1;
         glyph->s0 = (region.x+2)/(float)width;
         glyph->t0 = (region.y+2)/(float)height;
         glyph->s1 = (region.x+3)/(float)width;

--- a/texture-font.c
+++ b/texture-font.c
@@ -41,7 +41,6 @@
 #include <stdio.h>
 #include <assert.h>
 #include <math.h>
-#include <wchar.h>
 #include "texture-font.h"
 #include "platform.h"
 #include "utf8-utils.h"
@@ -192,15 +191,16 @@ texture_glyph_delete( texture_glyph_t *self )
 // ---------------------------------------------- texture_glyph_get_kerning ---
 float
 texture_glyph_get_kerning( const texture_glyph_t * self,
-                           const wchar_t charcode )
+                           const char * charcode )
 {
     size_t i;
+    uint32_t ucharcode = utf8_to_utf32( charcode );
 
     assert( self );
     for( i=0; i<vector_size(self->kerning); ++i )
     {
         kerning_t * kerning = (kerning_t *) vector_get( self->kerning, i );
-        if( kerning->charcode == charcode )
+        if( kerning->charcode == ucharcode )
         {
             return kerning->kerning;
         }

--- a/texture-font.c
+++ b/texture-font.c
@@ -312,8 +312,8 @@ texture_font_init(texture_font_t *self)
     FT_Done_Face( face );
     FT_Done_FreeType( library );
 
-    /* -1 is a special glyph */
-    texture_font_get_glyph( self, -1 );
+    /* NULL is a special glyph */
+    texture_font_get_glyph( self, NULL );
 
     return 0;
 }
@@ -662,7 +662,7 @@ texture_font_load_glyphs( texture_font_t * self,
 // ------------------------------------------------- texture_font_get_glyph ---
 texture_glyph_t *
 texture_font_get_glyph( texture_font_t * self,
-                        wchar_t charcode )
+                        const char * charcode )
 {
     texture_glyph_t *glyph;
 
@@ -670,18 +670,14 @@ texture_font_get_glyph( texture_font_t * self,
     assert( self->filename );
     assert( self->atlas );
 
-    char * ucharcode = utf16_to_utf8( charcode );
     /* Check if charcode has been already loaded */
-    if( (glyph = texture_font_find_glyph( self, charcode )) ) {
-        free( ucharcode );
+    if( (glyph = texture_font_find_glyph( self, charcode )) )
         return glyph;
-    }
-    free( ucharcode );
 
-    /* charcode -1 is special : it is used for line drawing (overline,
+    /* charcode NULL is special : it is used for line drawing (overline,
      * underline, strikethrough) and background.
      */
-    if( charcode == (wchar_t)(-1) )
+    if( !charcode )
     {
         size_t width  = self->atlas->width;
         size_t height = self->atlas->height;
@@ -707,12 +703,9 @@ texture_font_get_glyph( texture_font_t * self,
     }
 
     /* Glyph has not been already loaded */
-    char * buffer = utf16_to_utf8( charcode );
-    if( texture_font_load_glyphs( self, buffer ) == 0 )
+    if( texture_font_load_glyphs( self, charcode ) == 0 )
     {
-        free( buffer );
-        return *(texture_glyph_t **) vector_back( self->glyphs );
+        return texture_font_find_glyph( self, charcode );
     }
-    free( buffer );
     return NULL;
 }

--- a/texture-font.h
+++ b/texture-font.h
@@ -80,9 +80,9 @@ namespace ftgl {
 typedef struct kerning_t
 {
     /**
-     * Left character code in the kern pair.
+     * Left character code in the kern pair in UTF-32 LE encoding.
      */
-    wchar_t charcode;
+    uint32_t charcode;
 
     /**
      * Kerning value (in fractional pixels).

--- a/texture-font.h
+++ b/texture-font.h
@@ -35,6 +35,7 @@
 #define __TEXTURE_FONT_H__
 
 #include <stdlib.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -132,9 +133,9 @@ typedef struct kerning_t
 typedef struct texture_glyph_t
 {
     /**
-     * Wide character this glyph represents
+     * Character this glyph represents in UTF-32 LE encoding.
      */
-    wchar_t charcode;
+    uint32_t charcode;
 
     /**
      * Glyph id (used for display lists)

--- a/texture-font.h
+++ b/texture-font.h
@@ -433,7 +433,7 @@ typedef struct texture_font_t
  */
 float
 texture_glyph_get_kerning( const texture_glyph_t * self,
-                           const wchar_t charcode );
+                           const char * charcode );
 
 
 /**

--- a/texture-font.h
+++ b/texture-font.h
@@ -407,7 +407,7 @@ typedef struct texture_font_t
  */
   texture_glyph_t *
   texture_font_get_glyph( texture_font_t * self,
-                          wchar_t charcode );
+                          const char * charcode );
 
 
 /**

--- a/texture-font.h
+++ b/texture-font.h
@@ -414,14 +414,14 @@ typedef struct texture_font_t
  * Request the loading of several glyphs at once.
  *
  * @param self      a valid texture font
- * @param charcodes character codepoints to be loaded.
+ * @param charcodes UTF-8 encoded character codepoints to be loaded.
  *
  * @return Number of missed glyph if the texture is not big enough to hold
  *         every glyphs.
  */
   size_t
   texture_font_load_glyphs( texture_font_t * self,
-                            const wchar_t * charcodes );
+                            const char * charcodes );
 
 /**
  * Get the kerning between two horizontal glyphs.

--- a/utf8-utils.c
+++ b/utf8-utils.c
@@ -1,0 +1,211 @@
+/* =========================================================================
+ * Freetype GL - A C OpenGL Freetype engine
+ * Platform:    Any
+ * WWW:         https://github.com/rougier/freetype-gl
+ * -------------------------------------------------------------------------
+ * Copyright 2011,2012 Nicolas P. Rougier. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NICOLAS P. ROUGIER ''AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL NICOLAS P. ROUGIER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of Nicolas P. Rougier.
+ * ========================================================================= */
+
+#include <string.h>
+#include <wchar.h>
+#include "utf8-utils.h"
+
+// ----------------------------------------------------- utf8_surrogate_len ---
+size_t
+utf8_surrogate_len( const char* character )
+{
+    size_t result = 0;
+    char test_char;
+
+    if (!character)
+        return 0;
+
+    test_char = character[0];
+
+    if ((test_char & 0x80) == 0)
+        return 1;
+
+    while (test_char & 0x80)
+    {
+        test_char <<= 1;
+        result++;
+    }
+
+    return result;
+}
+
+// ------------------------------------------------------------ utf8_strlen ---
+size_t
+utf8_strlen( const char* string )
+{
+    const char* ptr = string;
+    size_t result = 0;
+
+    while (*ptr)
+    {
+        ptr += utf8_surrogate_len(ptr);
+        result++;
+    }
+
+    return result;
+}
+
+// ------------------------------------------------------ str_utf16_to_utf8 ---
+char *
+str_utf16_to_utf8( const wchar_t * string )
+{
+    size_t i;
+
+    char * result = NULL;
+    char * character = NULL;
+    size_t strlength = 0;
+
+    for( i = 0; i < wcslen( string ); ++i )
+    {
+        character = utf16_to_utf8( string[i] );
+        strlength = result ? strlen( result ) : 0;
+        result = realloc( result, strlength + utf8_surrogate_len( character ) + 1 );
+        result[strlength] = '\0';
+        strncat( result, character, utf8_surrogate_len( character ) );
+        free( character );
+    }
+
+    return result;
+}
+
+// ---------------------------------------------------------- utf8_to_utf16 ---
+wchar_t
+utf8_to_utf16( const char * character )
+{
+    return utf8_to_utf32( character );
+}
+
+// ---------------------------------------------------------- utf16_to_utf8 ---
+char *
+utf16_to_utf8( wchar_t character )
+{
+    wchar_t counter = character;
+    char * result = NULL;
+
+    if ( character == -1 )
+    {
+        return '\0';
+    }
+    else if ( character < 0x80 )
+    {
+        result = malloc( sizeof(char) * 2 );
+        result[0] = character & 0xFF;
+        result[1] = '\0';
+    }
+    else if ( character < 0x800 )
+    {
+        result = malloc( sizeof(char) * 3 );
+        result[0] = 0xC0 | ((character & 0x7C0) >> 6);
+        result[1] = 0x80 | (character & 0x3F);
+        result[2] = '\0';
+    }
+    else if ( character < 0x100000 )
+    {
+        result = malloc( sizeof(char) * 4 );
+        result[0] = 0xE0 | ((character & 0xF000) >> 12);
+        result[1] = 0x80 | ((character & 0xFC0) >> 6);
+        result[2] = 0x80 | (character & 0x3F);
+        result[3] = '\0';
+    }
+    else if ( character < 0x200000 )
+    {
+        result = malloc( sizeof(char) * 5 );
+        result[0] = 0xF0 | ((character & 0x1C0000) >> 18);
+        result[1] = 0x80 | ((character & 0x3F000) >> 12);
+        result[2] = 0x80 | ((character & 0xFC0) >> 6);
+        result[3] = 0x80 | (character & 0x3F);
+        result[4] = '\0';
+    }
+    else if ( character < 0x4000000 )
+    {
+        result = malloc( sizeof(char) * 6 );
+        result[0] = 0xF8 | ((character & 0x3000000) >> 24);
+        result[1] = 0x80 | ((character & 0xFC0000) >> 18);
+        result[2] = 0x80 | ((character & 0x3F000) >> 12);
+        result[3] = 0x80 | ((character & 0xFC0) >> 6);
+        result[4] = 0x80 | (character & 0x3F);
+        result[5] = '\0';
+    }
+    else
+    {
+        result = malloc( sizeof(char) * 7 );
+        result[0] = 0xFC | ((character & 0x40000000) >> 30);
+        result[1] = 0x80 | ((character & 0x3F000000) >> 24);
+        result[2] = 0x80 | ((character & 0xFC0000) >> 18);
+        result[3] = 0x80 | ((character & 0x3F000) >> 12);
+        result[4] = 0x80 | ((character & 0xFC0) >> 6);
+        result[5] = 0x80 | (character & 0x3F);
+        result[6] = '\0';
+    }
+
+    return result;
+}
+
+// ---------------------------------------------------------- utf8_to_utf32 ---
+uint32_t
+utf8_to_utf32( const char * character )
+{
+    uint32_t result = -1;
+
+    if( !character )
+    {
+        return result;
+    }
+
+    if( ( character[0] & 0x80 ) == 0x0 )
+    {
+        result = character[0];
+    }
+
+    if( ( character[0] & 0xC0 ) == 0xC0 )
+    {
+        result = ( ( character[0] & 0x3F ) << 6 ) | ( character[1] & 0x3F );
+    }
+
+    if( ( character[0] & 0xE0 ) == 0xE0 )
+    {
+        result = ( ( character[0] & 0x1F ) << ( 6 + 6 ) ) | ( ( character[1] & 0x3F ) << 6 ) | ( character[2] & 0x3F );
+    }
+
+    if( ( character[0] & 0xF0 ) == 0xF0 )
+    {
+        result = ( ( character[0] & 0x0F ) << ( 6 + 6 + 6 ) ) | ( ( character[1] & 0x3F ) << ( 6 + 6 ) ) | ( ( character[2] & 0x3F ) << 6 ) | ( character[3] & 0x3F );
+    }
+
+    if( ( character[0] & 0xF8 ) == 0xF8 )
+    {
+        result = ( ( character[0] & 0x07 ) << ( 6 + 6 + 6 + 6 ) ) | ( ( character[1] & 0x3F ) << ( 6 + 6 + 6 ) ) | ( ( character[2] & 0x3F ) << ( 6 + 6 ) ) | ( ( character[3] & 0x3F ) << 6 ) | ( character[4] & 0x3F );
+    }
+
+    return result;
+}

--- a/utf8-utils.c
+++ b/utf8-utils.c
@@ -32,7 +32,6 @@
  * ========================================================================= */
 
 #include <string.h>
-#include <wchar.h>
 #include "utf8-utils.h"
 
 // ----------------------------------------------------- utf8_surrogate_len ---
@@ -75,103 +74,6 @@ utf8_strlen( const char* string )
     return result;
 }
 
-// ------------------------------------------------------ str_utf16_to_utf8 ---
-char *
-str_utf16_to_utf8( const wchar_t * string )
-{
-    size_t i;
-
-    char * result = NULL;
-    char * character = NULL;
-    size_t strlength = 0;
-
-    for( i = 0; i < wcslen( string ); ++i )
-    {
-        character = utf16_to_utf8( string[i] );
-        strlength = result ? strlen( result ) : 0;
-        result = realloc( result, strlength + utf8_surrogate_len( character ) + 1 );
-        result[strlength] = '\0';
-        strncat( result, character, utf8_surrogate_len( character ) );
-        free( character );
-    }
-
-    return result;
-}
-
-// ---------------------------------------------------------- utf8_to_utf16 ---
-wchar_t
-utf8_to_utf16( const char * character )
-{
-    return utf8_to_utf32( character );
-}
-
-// ---------------------------------------------------------- utf16_to_utf8 ---
-char *
-utf16_to_utf8( wchar_t character )
-{
-    wchar_t counter = character;
-    char * result = NULL;
-
-    if ( character == -1 )
-    {
-        return '\0';
-    }
-    else if ( character < 0x80 )
-    {
-        result = malloc( sizeof(char) * 2 );
-        result[0] = character & 0xFF;
-        result[1] = '\0';
-    }
-    else if ( character < 0x800 )
-    {
-        result = malloc( sizeof(char) * 3 );
-        result[0] = 0xC0 | ((character & 0x7C0) >> 6);
-        result[1] = 0x80 | (character & 0x3F);
-        result[2] = '\0';
-    }
-    else if ( character < 0x100000 )
-    {
-        result = malloc( sizeof(char) * 4 );
-        result[0] = 0xE0 | ((character & 0xF000) >> 12);
-        result[1] = 0x80 | ((character & 0xFC0) >> 6);
-        result[2] = 0x80 | (character & 0x3F);
-        result[3] = '\0';
-    }
-    else if ( character < 0x200000 )
-    {
-        result = malloc( sizeof(char) * 5 );
-        result[0] = 0xF0 | ((character & 0x1C0000) >> 18);
-        result[1] = 0x80 | ((character & 0x3F000) >> 12);
-        result[2] = 0x80 | ((character & 0xFC0) >> 6);
-        result[3] = 0x80 | (character & 0x3F);
-        result[4] = '\0';
-    }
-    else if ( character < 0x4000000 )
-    {
-        result = malloc( sizeof(char) * 6 );
-        result[0] = 0xF8 | ((character & 0x3000000) >> 24);
-        result[1] = 0x80 | ((character & 0xFC0000) >> 18);
-        result[2] = 0x80 | ((character & 0x3F000) >> 12);
-        result[3] = 0x80 | ((character & 0xFC0) >> 6);
-        result[4] = 0x80 | (character & 0x3F);
-        result[5] = '\0';
-    }
-    else
-    {
-        result = malloc( sizeof(char) * 7 );
-        result[0] = 0xFC | ((character & 0x40000000) >> 30);
-        result[1] = 0x80 | ((character & 0x3F000000) >> 24);
-        result[2] = 0x80 | ((character & 0xFC0000) >> 18);
-        result[3] = 0x80 | ((character & 0x3F000) >> 12);
-        result[4] = 0x80 | ((character & 0xFC0) >> 6);
-        result[5] = 0x80 | (character & 0x3F);
-        result[6] = '\0';
-    }
-
-    return result;
-}
-
-// ---------------------------------------------------------- utf8_to_utf32 ---
 uint32_t
 utf8_to_utf32( const char * character )
 {

--- a/utf8-utils.h
+++ b/utf8-utils.h
@@ -73,37 +73,6 @@ namespace ftgl {
   utf8_strlen( const char* string );
 
   /**
-   * Converts a given UTF-16 LE encoded string to its UTF-8 equivalent
-   *
-   * @param string  An UTF-16 LE encoded and NULL terminated string
-   *
-   * @return  The equivalent of the given string in UTF-8 encoding.
-   */
-  char *
-  str_utf16_to_utf8( const wchar_t * string );
-
-  /**
-   * Converts a given UTF-8 encoded character to its UTF-16 LE equivalent
-   *
-   * @param character  An UTF-8 encoded character
-   *
-   * @return  The equivalent of the given character in UTF-16 LE
-   *          encoding.
-   */
-  wchar_t
-  utf8_to_utf16( const char * character );
-
-  /**
-   * Converts a given UTF-16 LE encoded character to its UTF-8 equivalent
-   *
-   * @param character  An UTF-16 LE encoded character
-   *
-   * @return  The equivalent of the given character in UTF-8 encoding.
-   */
-  char *
-  utf16_to_utf8( wchar_t character );
-
-  /**
    * Converts a given UTF-8 encoded character to its UTF-32 LE equivalent
    *
    * @param character  An UTF-8 encoded character

--- a/utf8-utils.h
+++ b/utf8-utils.h
@@ -1,0 +1,126 @@
+/* =========================================================================
+ * Freetype GL - A C OpenGL Freetype engine
+ * Platform:    Any
+ * WWW:         https://github.com/rougier/freetype-gl
+ * -------------------------------------------------------------------------
+ * Copyright 2011,2012 Nicolas P. Rougier. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NICOLAS P. ROUGIER ''AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL NICOLAS P. ROUGIER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of Nicolas P. Rougier.
+ * ========================================================================= */
+#ifndef __UTF8_UTILS_H__
+#define __UTF8_UTILS_H__
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+
+namespace ftgl {
+#endif
+
+/**
+ * @file    utf8-utils.h
+ * @author  Marcel Metz <mmetz@adrian-broher.net>
+ *
+ * defgroup utf8-utils UTF-8 Utilities
+ *
+ * @{
+ */
+
+  /**
+   * Returns the size in bytes of a given UTF-8 encoded character surrogate
+   *
+   * @param character  An UTF-8 encoded character
+   *
+   * @return  The length of the surrogate in bytes.
+   */
+  size_t
+  utf8_surrogate_len( const char* character );
+
+  /**
+   * Return the length of the given UTF-8 encoded and
+   * NULL terminated string.
+   *
+   * @param string  An UTF-8 encoded string
+   *
+   * @return  The length of the string in characters.
+   */
+  size_t
+  utf8_strlen( const char* string );
+
+  /**
+   * Converts a given UTF-16 LE encoded string to its UTF-8 equivalent
+   *
+   * @param string  An UTF-16 LE encoded and NULL terminated string
+   *
+   * @return  The equivalent of the given string in UTF-8 encoding.
+   */
+  char *
+  str_utf16_to_utf8( const wchar_t * string );
+
+  /**
+   * Converts a given UTF-8 encoded character to its UTF-16 LE equivalent
+   *
+   * @param character  An UTF-8 encoded character
+   *
+   * @return  The equivalent of the given character in UTF-16 LE
+   *          encoding.
+   */
+  wchar_t
+  utf8_to_utf16( const char * character );
+
+  /**
+   * Converts a given UTF-16 LE encoded character to its UTF-8 equivalent
+   *
+   * @param character  An UTF-16 LE encoded character
+   *
+   * @return  The equivalent of the given character in UTF-8 encoding.
+   */
+  char *
+  utf16_to_utf8( wchar_t character );
+
+  /**
+   * Converts a given UTF-8 encoded character to its UTF-32 LE equivalent
+   *
+   * @param character  An UTF-8 encoded character
+   *
+   * @return  The equivalent of the given character in UTF-32 LE
+   *          encoding.
+   */
+  uint32_t
+  utf8_to_utf32( const char * character );
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+}
+#endif
+
+#endif /* #define __UTF8_UTILS_H__ */


### PR DESCRIPTION
This pull requests removes the use of any wchar_t related functions and API interfaces in favor of UTF-8 encoded strings as already suggested/requested in the issues #6 and #69.  Functions now accept UTF-8 encoded char * strings instead of wchar_t * string with an undefined encoding.

To avoid additional allocation and freeing of memory blocks for the glyphs and kernings I have chosen to use uint32_t with an UTF-32 LE encoding as codepoint attributes.  This also improves readability of the code in comparison to an UTF-8 encoded codepoint in the glyph and kerning structs.

Most of the demos use only the ASCII subset (which is compatible with UTF-8) so I didn't add any dependencies to the Unicode functions header if not necessary.