### PR TITLE
Add support for building with msys2 mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ if(NOT HAVE_M_PI)
     endif()
 endif()
 
-if(WIN32 OR WIN64)
+if(NOT MINGW AND (WIN32 OR WIN64))
     set(GLEW_ROOT_DIR
         ${CMAKE_CURRENT_SOURCE_DIR}/windows/glew)
     set(ENV{FREETYPE_DIR}

--- a/CMakeModules/FindAntTweakBar.cmake
+++ b/CMakeModules/FindAntTweakBar.cmake
@@ -8,33 +8,39 @@
 #
 
 IF (WIN32)
-	FIND_PATH( ANT_TWEAK_BAR_INCLUDE_PATH AntTweakBar.h
-      PATHS
-		$ENV{ANT_TWEAK_BAR_ROOT}/include
-		DOC "The directory where AntTweakBar.h resides")
+    FIND_PATH( ANT_TWEAK_BAR_INCLUDE_PATH AntTweakBar.h
+        PATHS
+        $ENV{ANT_TWEAK_BAR_ROOT}/include
+        DOC "The directory where AntTweakBar.h resides")
 
-    FIND_LIBRARY( ANT_TWEAK_BAR_LIBRARY AntTweakBar
+    IF(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        SET(ANT_TWEAK_BAR_LIBRARY_NAME "AntTweakBar64")
+    ELSE()
+        SET(ANT_TWEAK_BAR_LIBRARY_NAME "AntTweakBar")
+    ENDIF()
+
+    FIND_LIBRARY( ANT_TWEAK_BAR_LIBRARY ${ANT_TWEAK_BAR_LIBRARY_NAME}
         PATHS
         $ENV{ANT_TWEAK_BAR_ROOT}/lib
         DOC "The AntTweakBar library")
-ELSE (WIN32)
-    FIND_PATH(ANT_TWEAK_BAR_INCLUDE_PATH AntTweakBar.h
-      PATHS
-      /usr/local/include
-      /usr/X11/include
-      /usr/include)
+ELSE ()
+    FIND_PATH( ANT_TWEAK_BAR_INCLUDE_PATH AntTweakBar.h
+        PATHS
+        /usr/local/include
+        /usr/X11/include
+        /usr/include)
 
-FIND_LIBRARY( ANT_TWEAK_BAR_LIBRARY AntTweakBar
-  PATHS
-    /usr/local
-    /usr/X11
-    /usr
-  PATH_SUFFIXES
-    lib64
-    lib
-    dylib
+    FIND_LIBRARY( ANT_TWEAK_BAR_LIBRARY AntTweakBar
+        PATHS
+        /usr/local
+        /usr/X11
+        /usr
+        PATH_SUFFIXES
+        lib64
+        lib
+        dylib
 )
-ENDIF (WIN32)
+ENDIF ()
 
 SET(ANT_TWEAK_BAR_FOUND "NO")
 IF (ANT_TWEAK_BAR_INCLUDE_PATH AND ANT_TWEAK_BAR_LIBRARY)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,3 +28,66 @@ Then:
 You can then run some demos under:
 
     cd demos
+
+
+## Windows MSYS2 MINGW64 with gcc 64-bit toolchain
+
+<http://msys2.github.io/>
+
+Be sure to check the MSYS2 wiki for install instructions / general information about the different shells etc. <https://sourceforge.net/p/msys2/wiki>
+We set up only a 64-bit toolchain for the sake of brevity.
+
+### Install required packages
+
+Open up the MSYS2 shell e.g. with msys2.exe
+
+```
+pacman -S mingw-w64-x86_64-gcc
+pacman -S mingw-w64-x86_64-cmake
+pacman -S mingw-w64-x86_64-make
+pacman -S mingw-w64-x86_64-glew
+pacman -S mingw-w64-x86_64-glfw
+pacman -S mingw-w64-x86_64-fontconfig
+pacman -S mingw-w64-x86_64-freetype
+pacman -S mingw-w64-x86_64-harfbuzz
+pacman -S mingw-w64-x86_64-pkg-config
+pacman -S mingw-w64-x86_64-doxygen
+```
+
+### Generate Makefile
+
+Open the MinGW64 shell e.g. via mingw64.exe
+We need to explicitly tell CMake to generate MinGW Makefiles and enable harfbuzz examples.
+
+```
+mkdir build
+cd build
+cmake -G "MinGW Makefiles"  -Dfreetype-gl_BUILD_HARFBUZZ=ON ..
+```
+
+**Note**: Harfbuzz examples only work with symbolic links enabled. See <https://github.com/git-for-windows/git/wiki/Symbolic-links>
+
+### Build demos
+
+```
+cmake --build .
+```
+
+### Run the demos
+
+Go to the `demo/` folder to try some demos.
+The harfbuzz examples are located in the `harfbuzz/` folder.
+
+To run the `atb-agg` demo you need to copy the file `AntTweakBar64.dll` into the `demo/` folder.
+
+### Troubleshooting
+**Note**: If you have the installer ending in 20160921.exe then you have to manually create /mingw32 and /mingw64 directories in the msys2 installation directory.
+This should be fixed with the next version of the installer.
+
+`mkdir -p /mingw{32,64}`
+
+Make sure to add your bin folder e.g. `C:\msys64\mingw64\bin`  to your PATH if you want to run the demos outside of the MINGW64 shell.
+
+If you get an error when you start your application from the Windows Explorer like "The procedure entry point inflateReset2 could not be located in the dynamic link library zlib1.dll":
+This is likely a PATH related problem. In this case some other zlib1.dll existent in one of the PATH folders was shadowing the needed zlib1.dll one of the mingw64/bin folder.
+The solution is to change the order of the PATH entries so that the mingw64 folder comes first.

--- a/demos/markup.c
+++ b/demos/markup.c
@@ -70,7 +70,7 @@ char *
 match_description( char * description )
 {
 
-#if defined _WIN32 || defined _WIN64
+#if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
     fprintf( stderr, "\"font_manager_match_description\" "
                      "not implemented for windows.\n" );
     return 0;


### PR DESCRIPTION
For context see #133 

The changes in this PR differ slightly from the ones described in the original issue.

- Link MATH_LIBRARY only if found
- Add support for msys2 MINGW64 based builds on Windows
- Add install & build instructions to INSTALL.md
- Add compiler flags for mingw builds to CMakeLists.txt
- Check for `__MINGW32__` in markup.c so that no error is printed
- Change FindAntTweakBar.cmake to find appropriate library for 32 or 64-bit
- Change harfbuzz examples to not use symlinks
- Check if GLFW3_LIBRARY is defined before linking, alternatively use glfw for linking (I ran into the same problem as described in  #124 and tried to come up with a reasonable fix)

Note: Symlinks are not deleted yet, but harfbuzz examples are changed to not use them anymore.

I was only able to test on Windows so far, in theory it should not break other platforms.
Happy to discuss.