### PR TITLE
cube demo: remove unused include

### DIFF
--- a/demos/cube.c
+++ b/demos/cube.c
@@ -6,7 +6,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "freetype-gl.h"
 #include "shader.h"
 #include "mat4.h"
 #include "vertex-buffer.h"


### PR DESCRIPTION
The cube demo is different than the others in that there's no text in it. Removing the redundant include makes that more clear / less confusing.