### PR TITLE
remove "rise" field from markup_t

### DIFF
--- a/demos/ansi.c
+++ b/demos/ansi.c
@@ -265,7 +265,6 @@ void init( void )
     markup.size    = 15.0;
     markup.bold    = 0;
     markup.italic  = 0;
-    markup.rise    = 0.0;
     markup.spacing = 0.0;
     markup.gamma   = 1.0;
     markup.foreground_color    = black;

--- a/demos/atb-agg.c
+++ b/demos/atb-agg.c
@@ -101,7 +101,6 @@ build_buffer( void )
         .size    = 10.0,
         .bold    = 0,
         .italic  = 0,
-        .rise    = 0.0,
         .spacing = p_interval,
         .gamma   = p_gamma,
         .foreground_color    = color,

--- a/demos/console.c
+++ b/demos/console.c
@@ -98,7 +98,6 @@ console_new( float font_size )
     normal.size    = font_size;
     normal.bold    = 0;
     normal.italic  = 0;
-    normal.rise    = 0.0;
     normal.spacing = 0.0;
     normal.gamma   = 1.0;
     normal.foreground_color    = black;

--- a/demos/gamma.c
+++ b/demos/gamma.c
@@ -58,7 +58,6 @@ void init( void )
     markup.size    = 15.0;
     markup.bold    = 0;
     markup.italic  = 0;
-    markup.rise    = 0.0;
     markup.spacing = 0.0;
     markup.gamma   = 1.0;
     markup.foreground_color    = white;

--- a/demos/markup.c
+++ b/demos/markup.c
@@ -107,7 +107,7 @@ void init()
     markup_t normal = {
         .family  = f_normal,
         .size    = 24.0, .bold    = 0,   .italic  = 0,
-        .rise    = 0.0,  .spacing = 0.0, .gamma   = 2.,
+        .spacing = 0.0,  .gamma   = 2.,
         .foreground_color    = white, .background_color    = none,
         .underline           = 0,     .underline_color     = white,
         .overline            = 0,     .overline_color      = white,

--- a/demos/outline.c
+++ b/demos/outline.c
@@ -112,7 +112,6 @@ void init( void )
     markup.size    = 80.0;
     markup.bold    = 0;
     markup.italic  = 0;
-    markup.rise    = 0.0;
     markup.spacing = 0.0;
     markup.gamma   = 1.5;
     markup.foreground_color    = white;

--- a/demos/subpixel.c
+++ b/demos/subpixel.c
@@ -59,7 +59,6 @@ void init()
     markup.size    = 9.0;
     markup.bold    = 0;
     markup.italic  = 0;
-    markup.rise    = 0.0;
     markup.spacing = 0.0;
     markup.gamma   = 1.0;
     markup.foreground_color    = black;

--- a/markup.h
+++ b/markup.h
@@ -40,7 +40,6 @@ namespace ftgl {
  *     .size = 24.0,
  *     .bold = 0,
  *     .italic = 0,
- *     .rise = 0.0,
  *     .spacing = 1.0,
  *     .gamma = 1.0,
  *     .foreground_color = black, .background_color    = none,
@@ -82,11 +81,6 @@ typedef struct markup_t
      * Whether text is italic.
      */
     int italic;
-
-    /**
-     * Vertical displacement from the baseline.
-     */
-    float rise;
 
     /**
      * Spacing between letters.


### PR DESCRIPTION
There's no support for it since f83aae3389b5ddaab56342a050828591baeb9899, so it may just cause confusion and mislead.