### PR TITLE
add missing static keyword to internal function file_exists

### DIFF
--- a/font-manager.c
+++ b/font-manager.c
@@ -16,7 +16,7 @@
 
 
 // ------------------------------------------------------------ file_exists ---
-int
+static int
 file_exists( const char * filename )
 {
     FILE * file = fopen( filename, "r" );


### PR DESCRIPTION
The `file_exists` function in `font-manager.c` isn't marked `static`, even though it is internal to that file and does not have a prefixed name, so it can easily clash with other functions of the same name. Not only it can clash but reportedly when creating Haskell bindings for freetype-gl it indeed does clash with a function of the same name from ghc's Win32Utils.

I didn't find other such functions with are not exposed in the header file or their names are unprefixed which aren't static - this appears to be the only one.