### PR TITLE
Remove calls to glBlendColor which do nothing

### DIFF
--- a/demos/ansi.c
+++ b/demos/ansi.c
@@ -332,11 +332,9 @@ void display( GLFWwindow* window )
         glBindTexture( GL_TEXTURE_2D, font_manager->atlas->id );
 
         glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
-        glBlendColor( 1, 1, 1, 1 );
 
         vertex_buffer_render( buffer->buffer, GL_TRIANGLES );
         glBindTexture( GL_TEXTURE_2D, 0 );
-        glBlendColor( 0, 0, 0, 0 );
         glUseProgram( 0 );
     }
 

--- a/demos/atb-agg.c
+++ b/demos/atb-agg.c
@@ -478,11 +478,9 @@ void display( GLFWwindow* window )
         glBindTexture( GL_TEXTURE_2D, font_manager->atlas->id );
 
         glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
-        glBlendColor( 1, 1, 1, 1 );
 
         vertex_buffer_render( text_buffer->buffer, GL_TRIANGLES );
         glBindTexture( GL_TEXTURE_2D, 0 );
-        glBlendColor( 0, 0, 0, 0 );
         glUseProgram( 0 );
     }
 

--- a/demos/gamma.c
+++ b/demos/gamma.c
@@ -153,11 +153,9 @@ void display( GLFWwindow* window )
         glBindTexture( GL_TEXTURE_2D, font_manager->atlas->id );
 
         glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
-        glBlendColor( 1, 1, 1, 1 );
 
         vertex_buffer_render( buffer->buffer, GL_TRIANGLES );
         glBindTexture( GL_TEXTURE_2D, 0 );
-        glBlendColor( 0, 0, 0, 0 );
         glUseProgram( 0 );
     }
 

--- a/demos/lcd.c
+++ b/demos/lcd.c
@@ -124,7 +124,6 @@ void display( GLFWwindow* window )
 
     glColor4f( 0, 0, 0, 1 );
     glBlendFunc( GL_ONE, GL_ONE_MINUS_SRC_ALPHA );
-    glBlendColor( 1, 1, 1, 1 );
     glEnable( GL_BLEND );
 
 

--- a/demos/markup.c
+++ b/demos/markup.c
@@ -226,16 +226,13 @@ void display( GLFWwindow* window )
         glBindTexture( GL_TEXTURE_2D, font_manager->atlas->id );
 
         glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
-        glBlendColor( 1, 1, 1, 1 );
 
         vertex_buffer_render( buffer->buffer, GL_TRIANGLES );
         glBindTexture( GL_TEXTURE_2D, 0 );
-        glBlendColor( 0, 0, 0, 0 );
         glUseProgram( 0 );
     }
 
     glBlendFunc( GL_ONE, GL_ONE_MINUS_SRC_ALPHA );
-    glBlendColor( 1.0, 1.0, 1.0, 1.0 );
     glUseProgram( bounds_shader );
     {
         glUniformMatrix4fv( glGetUniformLocation( bounds_shader, "model" ),

--- a/demos/subpixel.c
+++ b/demos/subpixel.c
@@ -126,15 +126,12 @@ void display( GLFWwindow* window )
         glBindTexture( GL_TEXTURE_2D, font_manager->atlas->id );
 
         glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
-        glBlendColor( 1, 1, 1, 1 );
 
         vertex_buffer_render( text_buffer->buffer, GL_TRIANGLES );
         glBindTexture( GL_TEXTURE_2D, 0 );
-        glBlendColor( 0, 0, 0, 0 );
         glUseProgram( 0 );
     }
     glBlendFunc( GL_ONE, GL_ONE_MINUS_SRC_ALPHA );
-    glBlendColor( 1.0, 1.0, 1.0, 1.0 );
     glUseProgram( bounds_shader );
     {
         glUniformMatrix4fv( glGetUniformLocation( bounds_shader, "model" ),


### PR DESCRIPTION
`glBlendColor` only has an effect when using `glBlendFunc` with
`GL_CONSTANT_COLOR`, `GL_ONE_MINUS_CONSTANT_COLOR`, `GL_CONSTANT_ALPHA`, or `GL_ONE_MINUS_CONSTANT_ALPHA`.
(according to https://www.opengl.org/sdk/docs/man4/html/glBlendFunc.xhtml).

As these blend funcs aren't used anywhere, the calls to `glBlendColor` are misleading,
and someone looking to learn from these examples might end up quite confused.