### PR TITLE
Exposed texture_font_find_glyph to the API

### DIFF
--- a/texture-font.h
+++ b/texture-font.h
@@ -391,7 +391,19 @@ typedef struct texture_font_t
   texture_font_get_glyph( texture_font_t * self,
                           const char * codepoint );
 
-
+/** 
+ * Request an already loaded glyph from the font. 
+ * 
+ * @param self      A valid texture font
+ * @param codepoint Character codepoint to be found in UTF-8 encoding.
+ *
+ * @return A pointer on the glyph or 0 if the glyph is not loaded
+ *
+ */
+ texture_glyph_t *
+ texture_font_find_glyph( texture_font_t * self,
+                          const char * codepoint );
+    
 /**
  * Request the loading of a given glyph.
  *

--- a/texture-font.h
+++ b/texture-font.h
@@ -398,7 +398,6 @@ typedef struct texture_font_t
  * @param codepoint Character codepoint to be found in UTF-8 encoding.
  *
  * @return A pointer on the glyph or 0 if the glyph is not loaded
- *
  */
  texture_glyph_t *
  texture_font_find_glyph( texture_font_t * self,


### PR DESCRIPTION
This allows the user to know when the font atlas really changed on a glyph request and therefore, if he needs to update his GL texture.
This avoids the unnecessary GL texture updates required with texture_font_get_glyph, which doesnt let the user know whether the glyph was "loaded" or "found" to use ftgls terminology, and therefore, if his GL texture requires an update.
As the methods implementation is already present and used internally inside texture_font_get_glyph, this should be a free performance gain for the user, just by allowing this slightly finer degree of control.

User code could look something like this:
texture_glyph_t* glyph_ptr = texture_font_find_glyph(users_texture_font, &users_required_character);
if(!glyph_ptr) {
    //glyph not found, must load it
    texture_font_load_glyph(users_texture_font, &users_required_character);
    glyph_ptr = texture_font_find_glyph(users_texture_font, &users_required_character);
    update_users_gl_texture(); 
}

As opposed to the current:
texture_glyph_t* glyph_ptr = texture_font_get_glyph(users_texture_font, &users_required_character);
update_users_gl_texture(); //probably unneccessary but you don't know

Obviously, you could still use the old shorter method if you don't care about performance.

This should also provide a solution for Issue #119.
