### PR TITLE
Added Feature to Enlarge the Texture atlas

### DIFF
--- a/texture-font.c
+++ b/texture-font.c
@@ -687,49 +687,44 @@ texture_font_get_glyph( texture_font_t * self,
 }
 
 // ------------------------------------------------- texture_font_enlarge_atlas ---
-	void
-		texture_font_enlarge_atlas(texture_font_t * self, size_t width_new,
-			size_t height_new)
-	{
-		assert(self);
-		assert(self->atlas);
-		//ensure size increased
-		assert(width_new >= self->atlas->width);
-		assert(height_new >= self->atlas->height);
-		assert(width_new + height_new > self->atlas->width + self->atlas->height);
-
-		texture_atlas_t* ta = self->atlas;
-		size_t width_old = ta->width;
-		size_t height_old = ta->height;
-
-		//allocate new buffer
-		unsigned char* data_old = ta->data;
-		ta->data = calloc(1,width_new*height_new * sizeof(char)*ta->depth);
-
-		//update atlas size
-		ta->width = width_new;
-		ta->height = height_new;
-		//add node reflecting the gained space on the right
-		ivec3 node;
-		node.x = width_old - 1;
-		node.y = 1;
-		node.z = width_new - width_old;
-		vector_push_back(ta->nodes, &node);
-
-		//copy over data from the old buffer, skipping first row and column because of the margin
-		size_t pixel_size = sizeof(char) * ta->depth;
-		size_t old_row_size = width_old * pixel_size;
-		texture_atlas_set_region(ta, 1, 1, width_old - 2, height_old - 2, data_old + old_row_size + pixel_size, old_row_size);
-		free(data_old);
-
-		//change uv coordinates of existing glyphs to reflect size change
-		float mulw = (float)width_old / width_new;
-		float mulh = (float)height_old / height_new;
-		for (size_t i = 0; i < vector_size(self->glyphs); i++) {
-			texture_glyph_t* g = *(texture_glyph_t**)vector_get(self->glyphs, i);
-			g->s0 *= mulw;
-			g->s1 *= mulw;
-			g->t0 *= mulh;
-			g->t1 *= mulh;
-		}
-	}
+void
+texture_font_enlarge_atlas( texture_font_t * self, size_t width_new,
+			    size_t height_new)
+{
+    assert(self);
+    assert(self->atlas);
+    //ensure size increased
+    assert(width_new >= self->atlas->width);
+    assert(height_new >= self->atlas->height);
+    assert(width_new + height_new > self->atlas->width + self->atlas->height);    
+    texture_atlas_t* ta = self->atlas;
+    size_t width_old = ta->width;
+    size_t height_old = ta->height;    
+    //allocate new buffer
+    unsigned char* data_old = ta->data;
+    ta->data = calloc(1,width_new*height_new * sizeof(char)*ta->depth);    
+    //update atlas size
+    ta->width = width_new;
+    ta->height = height_new;
+    //add node reflecting the gained space on the right
+    ivec3 node;
+    node.x = width_old - 1;
+    node.y = 1;
+    node.z = width_new - width_old;
+    vector_push_back(ta->nodes, &node);    
+    //copy over data from the old buffer, skipping first row and column because of the margin
+    size_t pixel_size = sizeof(char) * ta->depth;
+    size_t old_row_size = width_old * pixel_size;
+    texture_atlas_set_region(ta, 1, 1, width_old - 2, height_old - 2, data_old + old_row_size + pixel_size, old_row_size);
+    free(data_old);    
+    //change uv coordinates of existing glyphs to reflect size change
+    float mulw = (float)width_old / width_new;
+    float mulh = (float)height_old / height_new;
+    for (size_t i = 0; i < vector_size(self->glyphs); i++) {
+    	texture_glyph_t* g = *(texture_glyph_t**)vector_get(self->glyphs, i);
+    	g->s0 *= mulw;
+    	g->s1 *= mulw;
+    	g->t0 *= mulh;
+    	g->t1 *= mulh;
+    }
+}

--- a/texture-font.c
+++ b/texture-font.c
@@ -720,7 +720,8 @@ texture_font_enlarge_atlas( texture_font_t * self, size_t width_new,
     //change uv coordinates of existing glyphs to reflect size change
     float mulw = (float)width_old / width_new;
     float mulh = (float)height_old / height_new;
-    for (size_t i = 0; i < vector_size(self->glyphs); i++) {
+    size_t i;
+    for (i = 0; i < vector_size(self->glyphs); i++) {
     	texture_glyph_t* g = *(texture_glyph_t**)vector_get(self->glyphs, i);
     	g->s0 *= mulw;
     	g->s1 *= mulw;

--- a/texture-font.c
+++ b/texture-font.c
@@ -707,11 +707,13 @@ texture_font_enlarge_atlas( texture_font_t * self, size_t width_new,
     ta->width = width_new;
     ta->height = height_new;
     //add node reflecting the gained space on the right
-    ivec3 node;
-    node.x = width_old - 1;
-    node.y = 1;
-    node.z = width_new - width_old;
-    vector_push_back(ta->nodes, &node);    
+    if(width_new>width_old){
+    	ivec3 node;
+        node.x = width_old - 1;
+        node.y = 1;
+        node.z = width_new - width_old;
+        vector_push_back(ta->nodes, &node);    
+    }
     //copy over data from the old buffer, skipping first row and column because of the margin
     size_t pixel_size = sizeof(char) * ta->depth;
     size_t old_row_size = width_old * pixel_size;

--- a/texture-font.h
+++ b/texture-font.h
@@ -428,7 +428,18 @@ typedef struct texture_font_t
   size_t
   texture_font_load_glyphs( texture_font_t * self,
                             const char * codepoints );
-
+  /*
+   *Increases the size of a fonts texture atlas
+   *Invalidates all pointers to font->atlas->data
+   *Changes the UV Coordinates of existing glyphs in the font
+   *
+   *@param self A valid texture font
+   *@param width_new Width of the texture atlas after resizing (must be bigger or equal to current width)
+   *@param height_new Height of the texture atlas after resizing (must be bigger or equal to current height)
+   */
+  void
+  texture_font_enlarge_atlas( texture_font_t * self, size_t width_new,
+							  size_t height_new);
 /**
  * Get the kerning between two horizontal glyphs.
  *


### PR DESCRIPTION
Added the method texture_font_enlarge_atlas which allows resizing of the texture atlas while keeping all existing glyphs validated. 
Unfortunately it has to be part of the texture_font_t "class" as the glyphs' uvs need to be updated.