### PR TITLE
Fix scaling distortion

### DIFF
--- a/texture-font.c
+++ b/texture-font.c
@@ -562,13 +562,7 @@ cleanup_stroker:
         int top;
         int right;
         int bottom;
-    } padding = { 0, 0, 1, 1 };
-
-    if( self->rendermode == RENDER_SIGNED_DISTANCE_FIELD )
-    {
-        padding.top = 1;
-        padding.left = 1;
-    }
+    } padding = { 1, 1, 1, 1 };
 
     size_t src_w = ft_bitmap.width/self->atlas->depth;
     size_t src_h = ft_bitmap.rows;

--- a/texture-font.c
+++ b/texture-font.c
@@ -604,10 +604,13 @@ cleanup_stroker:
 
     free( buffer );
 
+    x += padding.left;
+    y += padding.top;
+
     glyph = texture_glyph_new( );
     glyph->codepoint = utf8_to_utf32( codepoint );
-    glyph->width    = tgt_w;
-    glyph->height   = tgt_h;
+    glyph->width    = src_w;
+    glyph->height   = src_h;
     glyph->rendermode = self->rendermode;
     glyph->outline_thickness = self->outline_thickness;
     glyph->offset_x = ft_glyph_left;


### PR DESCRIPTION
- Added a pixel to the left and top of a glyph to get rid of distortion when scaling. I suspect this only needs to be used with glyphs that are adjacent to the edges of the texture but given that the packing algorithm here is pretty awesome, it doesn't look like this will have a major impact on the texture's size.
- Moved the texture coordinates by the left&top padding and used the unpadded glyph size for the calculation of the coordinates. It seems to me that glyphs are stretched by one pixel on both axis if we use the padded size.