### PR TITLE
Fix buffer over-read and performance bug

### DIFF
--- a/text-buffer.c
+++ b/text-buffer.c
@@ -218,7 +218,7 @@ text_buffer_add_text( text_buffer_t * self,
         }
     }
 
-    for( i = 0; utf8_strlen( text + i ) && length; i += utf8_surrogate_len( text + i ) )
+    for( i = 0; length; i += utf8_surrogate_len( text + i ) )
     {
         text_buffer_add_char( self, pen, markup, text + i, prev_character );
         prev_character = text + i;


### PR DESCRIPTION
In `text_buffer_add_text`, for each code-point `utf8_strlen` is called, causing quadratic performance instead of linear, as well as a memory read outside the buffer for strings that are provided with an explicit length instead of null termination. The fix is simply to use the provided (or previously calculated) `length`.