### PR TITLE
Use Freetype inspired error numbering system, while keeping compatibi…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,8 @@ set(FREETYPE_GL_HDR
     vector.h
     vertex-attribute.h
     vertex-buffer.h
+    freetype-gl-err.h
+    freetype-gl-errdef.h
 )
 
 set(FREETYPE_GL_SRC
@@ -134,6 +136,7 @@ set(FREETYPE_GL_SRC
     vector.c
     vertex-attribute.c
     vertex-buffer.c
+    freetype-gl-err.c
 )
 
 add_library(freetype-gl STATIC

--- a/font-manager.c
+++ b/font-manager.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "font-manager.h"
-
+#include "freetype-gl-err.h"
 
 // ------------------------------------------------------------ file_exists ---
 static int
@@ -38,9 +38,10 @@ font_manager_new( size_t width, size_t height, size_t depth )
     self = (font_manager_t *) malloc( sizeof(font_manager_t) );
     if( !self )
     {
-        fprintf( stderr,
-                 "line %d: No more memory for allocating data\n", __LINE__ );
-        exit( EXIT_FAILURE );
+        freetype_gl_error( Out_Of_Memory,
+			   "line %d: No more memory for allocating data\n", __LINE__ );
+	return NULL;
+        /* exit( EXIT_FAILURE ); */ /* Never ever exit from a library */
     }
     self->atlas = atlas;
     self->fonts = vector_new( sizeof(texture_font_t *) );
@@ -124,7 +125,8 @@ font_manager_get_from_filename( font_manager_t *self,
         texture_font_load_glyphs( font, self->cache );
         return font;
     }
-    fprintf( stderr, "Unable to load \"%s\" (size=%.1f)\n", filename, size );
+    freetype_gl_error( Cannot_Load_File,
+		       "Unable to load \"%s\" (size=%.1f)\n", filename, size );
     return 0;
 }
 
@@ -149,13 +151,15 @@ font_manager_get_from_description( font_manager_t *self,
     else
     {
 #if defined(_WIN32) || defined(_WIN64)
-        fprintf( stderr, "\"font_manager_get_from_description\" not implemented yet.\n" );
+        freetype_gl_error( Unimplemented_Function,
+			   "\"font_manager_get_from_description\" not implemented yet.\n" );
         return 0;
 #endif
         filename = font_manager_match_description( self, family, size, bold, italic );
         if( !filename )
         {
-            fprintf( stderr, "No \"%s (size=%.1f, bold=%d, italic=%d)\" font available.\n",
+            freetype_gl_error( Font_Unavailable,
+			       "No \"%s (size=%.1f, bold=%d, italic=%d)\" font available.\n",
                      family, size, bold, italic );
             return 0;
         }
@@ -191,7 +195,8 @@ font_manager_match_description( font_manager_t * self,
     return 0;
 #else
 #  if defined _WIN32 || defined _WIN64
-      fprintf( stderr, "\"font_manager_match_description\" not implemented for windows.\n" );
+      freetype_gl_error( Unimplemented_Function,
+			 "\"font_manager_match_description\" not implemented for windows.\n" );
       return 0;
 #  endif
     char *filename = 0;
@@ -219,7 +224,8 @@ font_manager_match_description( font_manager_t * self,
 
     if ( !match )
     {
-        fprintf( stderr, "fontconfig error: could not match family '%s'", family );
+        freetype_gl_error( Cant_Match_Family,
+			   "fontconfig error: could not match family '%s'", family );
         return 0;
     }
     else
@@ -228,7 +234,8 @@ font_manager_match_description( font_manager_t * self,
         FcResult result = FcPatternGet( match, FC_FILE, 0, &value );
         if ( result )
         {
-            fprintf( stderr, "fontconfig error: could not match family '%s'", family );
+            freetype_gl_error( Cant_Match_Family,
+			       "fontconfig error: could not match family '%s'", family );
         }
         else
         {

--- a/freetype-gl-err.c
+++ b/freetype-gl-err.c
@@ -11,6 +11,20 @@
 __THREAD int freetype_gl_errno=0;
 __THREAD char * freetype_gl_message=NULL;
 
+#ifdef __ANDROID__
+#include <android/log.h>
+#define  LOG_TAG    "freetype-gl"
+void freetype_gl_errhook_default(int errno, char* message, char* fmt, ...)
+{
+  va_list myargs;
+  va_start(myargs, fmt);
+  __android_log_print(ANDROID_LOG_ERROR, LOG_TAG,
+		      "Freetype GL Error %03x %s:\n", errno, message);
+  __android_log_vprint(ANDROID_LOG_ERROR, LOG_TAG,
+		       fmt, myargs);
+  va_end(myargs);
+}
+#else
 void freetype_gl_errhook_default(int errno, char* message, char* fmt, ...)
 {
   va_list myargs;
@@ -19,6 +33,7 @@ void freetype_gl_errhook_default(int errno, char* message, char* fmt, ...)
   vfprintf(stderr, fmt, myargs);
   va_end(myargs);
 }
+#endif
 
 extern const struct {
     int          code;

--- a/freetype-gl-err.c
+++ b/freetype-gl-err.c
@@ -1,0 +1,48 @@
+/* Freetype GL - A C OpenGL Freetype engine
+ *
+ * Distributed under the OSI-approved BSD 2-Clause License.  See accompanying
+ * file `LICENSE` for more details.
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+#include "freetype-gl.h"
+
+__THREAD int freetype_gl_errno=0;
+__THREAD char * freetype_gl_message=NULL;
+
+void freetype_gl_errhook_default(int errno, char* message, char* fmt, ...)
+{
+  va_list myargs;
+  va_start(myargs, fmt);
+  fprintf(stderr, "Freetype GL Error %03x %s:\n", errno, message);
+  vfprintf(stderr, fmt, myargs);
+  va_end(myargs);
+}
+
+extern const struct {
+    int          code;
+    const char*  message;
+} FT_Errors[];
+
+char* freetype_gl_errstr(int errno)
+{
+  if(errno >= FTGL_ERR_BASE)
+    return freetype_gl_errstrs[errno-FTGL_ERR_BASE];
+  else
+    return (char*)FT_Errors[errno].message;
+}
+
+void (*freetype_gl_errhook)(int errno, char* message, char* fmt, ...) = freetype_gl_errhook_default;
+
+#undef FTGL_ERRORDEF_
+#define FTGL_ERRORDEF_( e, v, s ) s,
+#undef __FREETYPE_GL_ERRORS_H__
+#undef FTGL_ERROR_START_LIST
+#undef FTGL_ERROR_END_LIST
+
+#define FTGL_ERROR_START_LIST char* freetype_gl_errstrs[] = {
+#define FTGL_ERROR_END_LIST };
+
+#include "freetype-gl-errdef.h"
+

--- a/freetype-gl-err.h
+++ b/freetype-gl-err.h
@@ -8,6 +8,8 @@
 
 #if defined(__GNUC__) || defined(__clang__)
 #define __THREAD __thread
+#elif defined(_MSC_VER)
+#define __THREAD __declspec( thread )
 #else
 #define __THREAD
 #endif

--- a/freetype-gl-err.h
+++ b/freetype-gl-err.h
@@ -1,0 +1,80 @@
+/* Freetype GL - A C OpenGL Freetype engine
+ *
+ * Distributed under the OSI-approved BSD 2-Clause License.  See accompanying
+ * file `LICENSE` for more details.
+ */
+#ifndef __FREETYPE_GL_ERR_H__
+#define __FREETYPE_GL_ERR_H__
+
+#if defined(__GNUC__) || defined(__clang__)
+#define __THREAD __thread
+#else
+#define __THREAD
+#endif
+
+/*********** public error API ***********/
+/**
+ * freetype_gl_errno    is the error number if a freetype-gl function fails
+ *                      Errors < FTGL_ERR_BASE are pass-through from Freetype
+ */
+extern __THREAD int freetype_gl_errno;
+/**
+ * freetype_gl_message  is the error message if a freetype-gl function fails
+ */
+extern __THREAD char * freetype_gl_message;
+/**
+ * freetype_gl_errhook  is a function pointer to display error number
+ *                      and message, default is using fprintf on stderr
+ */
+extern void (*freetype_gl_errhook)(int errno, char* message, char* string, ...);
+/**
+ * freetype_gl_errstr   converts an errno to the message (including FT_errors)
+ */
+extern char* freetype_gl_errstr(int errno);
+
+#ifndef FTGL_ERR_PREFIX
+# define FTGL_ERR_PREFIX  FTGL_Err_
+#endif
+
+#ifndef FTGL_ERR_CAT
+# define FTGL_ERR_XCAT( x, y )  x ## y
+# define FTGL_ERR_CAT( x, y )   FTGL_ERR_XCAT( x, y )
+#endif
+#define FTGL_ERR_BASE  0x100 /* Freetype GL errors start at 0x100 */
+    
+extern char* freetype_gl_errstrs[];
+
+#define freetype_gl_error(errno, ...)			     \
+  freetype_gl_errno = FTGL_ERR_CAT( FTGL_ERR_PREFIX, errno); \
+  freetype_gl_message = freetype_gl_errstrs[FTGL_ERR_CAT( FTGL_ERR_PREFIX, errno)-FTGL_ERR_BASE]; \
+  freetype_gl_errhook(freetype_gl_errno, freetype_gl_message, __VA_ARGS__);
+
+#define freetype_error(error, ...)		     \
+  freetype_gl_errno = FT_Errors[error].code; \
+  freetype_gl_message = (char*)FT_Errors[error].message;		\
+  freetype_gl_errhook(freetype_gl_errno, freetype_gl_message, __VA_ARGS__);
+
+#define FTGL_ERRSTR_MAX 0x100
+
+#ifndef FTGL_ERRORDEF_
+# ifndef FTGL_ERRORDEF
+
+#  define FTGL_ERRORDEF( e, v, s )  e = v,
+#  define FTGL_ERROR_START_LIST     enum {
+#  define FTGL_ERROR_END_LIST       FTGL_ERR_CAT( FTGL_ERR_PREFIX, Max ) };
+
+#  ifdef __cplusplus
+#   define FTGL_NEED_EXTERN_C
+  extern "C" {
+#  endif
+    
+# endif /* !FTGL_ERRORDEF */
+
+    /* this macro is used to define an error */
+# define FTGL_ERRORDEF_( e, v, s )						\
+          FTGL_ERRORDEF( FTGL_ERR_CAT( FTGL_ERR_PREFIX, e ), v + FTGL_ERR_BASE, s )
+# endif /* !FTGL_ERRORDEF_ */
+
+#include <freetype-gl-errdef.h>
+    
+#endif /* FREETYPE_GL_ERR_H */

--- a/freetype-gl-errdef.h
+++ b/freetype-gl-errdef.h
@@ -1,0 +1,37 @@
+/* Freetype GL - A C OpenGL Freetype engine
+ *
+ * Distributed under the OSI-approved BSD 2-Clause License.  See accompanying
+ * file `LICENSE` for more details.
+ */
+
+#ifndef __FREETYPE_GL_ERRORS_H__
+#define __FREETYPE_GL_ERRORS_H__
+
+FTGL_ERROR_START_LIST
+
+  FTGL_ERRORDEF_( Texture_Atlas_Full,			0x00,
+		  "Texture atlas is full" )
+  FTGL_ERRORDEF_( Cannot_Load_File,			0x01,
+		  "unable to load file" )
+  FTGL_ERRORDEF_( Font_Unavailable,			0x02,
+		  "no font available" )
+  FTGL_ERRORDEF_( No_Font_File_Given,			0x03,
+		  "no font file given" )
+  FTGL_ERRORDEF_( Out_Of_Memory,			0x04,
+		  "out of memory" )
+  FTGL_ERRORDEF_( Unimplemented_Function,		0x05,
+		  "unimplemented function" )
+  FTGL_ERRORDEF_( Cant_Match_Family,			0x06,
+		  "fontconfig error: could not match family" )
+  FTGL_ERRORDEF_( No_Font_In_Markup,			0x07,
+		  "Markup doesn't have a font" )
+  FTGL_ERRORDEF_( No_Size_Specified,			0x08,
+		  "No size specified for attribute" )
+  FTGL_ERRORDEF_( No_Format_Specified,			0x09,
+		  "No format specified for attribute" )
+  FTGL_ERRORDEF_( Vertex_Attribute_Format_Wrong,	0x0A,
+		  "Vertex attribute format not understood" )
+
+FTGL_ERROR_END_LIST
+
+#endif

--- a/freetype-gl.h
+++ b/freetype-gl.h
@@ -12,6 +12,7 @@
 #include "vector.h"
 #include "texture-atlas.h"
 #include "texture-font.h"
+#include "freetype-gl-err.h"
 
 #ifdef __cplusplus
 #ifndef NOT_USING_FT_GL_NAMESPACE

--- a/harfbuzz/CMakeLists.txt
+++ b/harfbuzz/CMakeLists.txt
@@ -18,6 +18,8 @@ set(FREETYPE_GL_HB_HDR
     vector.h
     vertex-attribute.h
     vertex-buffer.h
+    freetype-gl-err.h
+    freetype-gl-errdef.h
 )
 
 set(FREETYPE_GL_HB_SRC
@@ -26,6 +28,7 @@ set(FREETYPE_GL_HB_SRC
     vector.c
     vertex-attribute.c
     vertex-buffer.c
+    freetype-gl-err.c
 )
 
 add_library(freetype-gl-hb STATIC

--- a/harfbuzz/freetype-gl-err.c
+++ b/harfbuzz/freetype-gl-err.c
@@ -1,0 +1,1 @@
+../freetype-gl-err.c

--- a/harfbuzz/freetype-gl-err.h
+++ b/harfbuzz/freetype-gl-err.h
@@ -1,0 +1,1 @@
+../freetype-gl-err.h

--- a/harfbuzz/freetype-gl-errdef.h
+++ b/harfbuzz/freetype-gl-errdef.h
@@ -1,0 +1,1 @@
+../freetype-gl-errdef.h

--- a/text-buffer.c
+++ b/text-buffer.c
@@ -12,6 +12,7 @@
 #include "opengl.h"
 #include "text-buffer.h"
 #include "utf8-utils.h"
+#include "freetype-gl-err.h"
 
 #define SET_GLYPH_VERTEX(value,x0,y0,z0,s0,t0,r,g,b,a,sh,gm) { \
 	glyph_vertex_t *gv=&value;                                 \
@@ -191,7 +192,8 @@ text_buffer_add_text( text_buffer_t * self,
 
     if( !markup->font )
     {
-        fprintf( stderr, "Houston, we've got a problem !\n" );
+        freetype_gl_error( No_Font_In_Markup,
+			   "Houston, we've got a problem !\n" );
         return;
     }
 

--- a/texture-atlas.c
+++ b/texture-atlas.c
@@ -9,7 +9,7 @@
 #include <assert.h>
 #include <limits.h>
 #include "texture-atlas.h"
-
+#include "freetype-gl-err.h"
 
 // ------------------------------------------------------ texture_atlas_new ---
 texture_atlas_t *
@@ -26,9 +26,10 @@ texture_atlas_new( const size_t width,
     assert( (depth == 1) || (depth == 3) || (depth == 4) );
     if( self == NULL)
     {
-        fprintf( stderr,
-                 "line %d: No more memory for allocating data\n", __LINE__ );
-        exit( EXIT_FAILURE );
+        freetype_gl_error( Out_Of_Memory,
+			   "line %d: No more memory for allocating data\n", __LINE__ );
+	return NULL;
+        /* exit( EXIT_FAILURE ); */ /* Never exit from a library */
     }
     self->nodes = vector_new( sizeof(ivec3) );
     self->used = 0;
@@ -43,9 +44,9 @@ texture_atlas_new( const size_t width,
 
     if( self->data == NULL)
     {
-        fprintf( stderr,
-                 "line %d: No more memory for allocating data\n", __LINE__ );
-        exit( EXIT_FAILURE );
+        freetype_gl_error( Out_Of_Memory,
+			   "line %d: No more memory for allocating data\n", __LINE__ );
+	return NULL;
     }
 
     return self;
@@ -214,9 +215,10 @@ texture_atlas_get_region( texture_atlas_t * self,
     node = (ivec3 *) malloc( sizeof(ivec3) );
     if( node == NULL)
     {
-        fprintf( stderr,
-                 "line %d: No more memory for allocating data\n", __LINE__ );
-        exit( EXIT_FAILURE );
+        freetype_gl_error( Out_Of_Memory,
+			   "line %d: No more memory for allocating data\n", __LINE__ );
+	return (ivec4){{-1,-1,0,0}};
+        /* exit( EXIT_FAILURE ); */ /* Never exit from a library */
     }
     node->x = region.x;
     node->y = region.y + height;

--- a/texture-font.c
+++ b/texture-font.c
@@ -17,6 +17,7 @@
 #include "texture-font.h"
 #include "platform.h"
 #include "utf8-utils.h"
+#include "freetype-gl-err.h"
 
 #define HRES  64
 #define HRESf 64.f
@@ -50,7 +51,7 @@ texture_font_load_face(texture_font_t *self, float size,
     /* Initialize library */
     error = FT_Init_FreeType(library);
     if(error) {
-        fprintf(stderr, "FT_Error (0x%02x) : %s\n",
+        freetype_error(error, "FT_Error (0x%02x) : %s\n",
                 FT_Errors[error].code, FT_Errors[error].message);
         goto cleanup;
     }
@@ -68,7 +69,7 @@ texture_font_load_face(texture_font_t *self, float size,
     }
 
     if(error) {
-        fprintf(stderr, "FT_Error (line %d, code 0x%02x) : %s\n",
+        freetype_error( error, "FT_Error (line %d, code 0x%02x) : %s\n",
                 __LINE__, FT_Errors[error].code, FT_Errors[error].message);
         goto cleanup_library;
     }
@@ -76,7 +77,7 @@ texture_font_load_face(texture_font_t *self, float size,
     /* Select charmap */
     error = FT_Select_Charmap(*face, FT_ENCODING_UNICODE);
     if(error) {
-        fprintf(stderr, "FT_Error (line %d, code 0x%02x) : %s\n",
+        freetype_error( error, "FT_Error (line %d, code 0x%02x) : %s\n",
                 __LINE__, FT_Errors[error].code, FT_Errors[error].message);
         goto cleanup_face;
     }
@@ -85,7 +86,7 @@ texture_font_load_face(texture_font_t *self, float size,
     error = FT_Set_Char_Size(*face, (int)(size * HRES), 0, DPI * HRES, DPI);
 
     if(error) {
-        fprintf(stderr, "FT_Error (line %d, code 0x%02x) : %s\n",
+        freetype_error( error, "FT_Error (line %d, code 0x%02x) : %s\n",
                 __LINE__, FT_Errors[error].code, FT_Errors[error].message);
         goto cleanup_face;
     }
@@ -109,7 +110,7 @@ texture_glyph_new(void)
 {
     texture_glyph_t *self = (texture_glyph_t *) malloc( sizeof(texture_glyph_t) );
     if(self == NULL) {
-        fprintf( stderr,
+        freetype_gl_error( Out_Of_Memory,
                 "line %d: No more memory for allocating data\n", __LINE__);
         return NULL;
     }
@@ -273,8 +274,8 @@ texture_font_new_from_file(texture_atlas_t *atlas, const float pt_size,
 
     self = calloc(1, sizeof(*self));
     if (!self) {
-        fprintf(stderr,
-                "line %d: No more memory for allocating data\n", __LINE__);
+        freetype_gl_error( Out_Of_Memory,
+			   "line %d: No more memory for allocating data\n", __LINE__);
         return NULL;
     }
 
@@ -304,8 +305,8 @@ texture_font_new_from_memory(texture_atlas_t *atlas, float pt_size,
 
     self = calloc(1, sizeof(*self));
     if (!self) {
-        fprintf(stderr,
-                "line %d: No more memory for allocating data\n", __LINE__);
+        freetype_gl_error( Out_Of_Memory,
+			   "line %d: No more memory for allocating data\n", __LINE__);
         return NULL;
     }
 
@@ -417,10 +418,11 @@ texture_font_load_glyph( texture_font_t * self,
                                             -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
         if ( region.x < 0 )
         {
-            fprintf( stderr, "Texture atlas is full (line %d)\n",  __LINE__ );
+            freetype_gl_error( Texture_Atlas_Full,
+			       "Texture atlas is full (line %d)\n",  __LINE__ );
             FT_Done_Face( face );
             FT_Done_FreeType( library );
-            return NULL;
+            return 0;
         }
         texture_atlas_set_region( self->atlas, region.x, region.y, 4, 4, data, 0 );
         glyph->codepoint = -1;
@@ -474,8 +476,8 @@ texture_font_load_glyph( texture_font_t * self,
     error = FT_Load_Glyph( face, glyph_index, flags );
     if( error )
     {
-        fprintf( stderr, "FT_Error (line %d, code 0x%02x) : %s\n",
-                 __LINE__, FT_Errors[error].code, FT_Errors[error].message );
+        freetype_error( error, "FT_Error (line %d, code 0x%02x) : %s\n",
+			__LINE__, FT_Errors[error].code, FT_Errors[error].message);
         FT_Done_Face( face );
         FT_Done_FreeType( library );
         return 0;
@@ -497,7 +499,7 @@ texture_font_load_glyph( texture_font_t * self,
 
         if( error )
         {
-            fprintf(stderr, "FT_Error (0x%02x) : %s\n",
+            freetype_error( error, "FT_Error (0x%02x) : %s\n",
                     FT_Errors[error].code, FT_Errors[error].message);
             goto cleanup_stroker;
         }
@@ -512,7 +514,7 @@ texture_font_load_glyph( texture_font_t * self,
 
         if( error )
         {
-            fprintf(stderr, "FT_Error (0x%02x) : %s\n",
+            freetype_error( error, "FT_Error (0x%02x) : %s\n",
                     FT_Errors[error].code, FT_Errors[error].message);
             goto cleanup_stroker;
         }
@@ -526,7 +528,7 @@ texture_font_load_glyph( texture_font_t * self,
 
         if( error )
         {
-            fprintf(stderr, "FT_Error (0x%02x) : %s\n",
+            freetype_error( error, "FT_Error (0x%02x) : %s\n",
                     FT_Errors[error].code, FT_Errors[error].message);
             goto cleanup_stroker;
         }
@@ -538,7 +540,7 @@ texture_font_load_glyph( texture_font_t * self,
 
         if( error )
         {
-            fprintf(stderr, "FT_Error (0x%02x) : %s\n",
+            freetype_error( error, "FT_Error (0x%02x) : %s\n",
                     FT_Errors[error].code, FT_Errors[error].message);
             goto cleanup_stroker;
         }
@@ -582,7 +584,8 @@ cleanup_stroker:
 
     if ( region.x < 0 )
     {
-        fprintf( stderr, "Texture atlas is full (line %d)\n",  __LINE__ );
+        freetype_gl_error( Texture_Atlas_Full,
+			   "Texture atlas is full (line %d)\n",  __LINE__ );
         FT_Done_Face( face );
         FT_Done_FreeType( library );
         return 0;

--- a/vector.c
+++ b/vector.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "vector.h"
-
+#include "freetype-gl-err.h"
 
 
 // ------------------------------------------------------------- vector_new ---
@@ -20,9 +20,9 @@ vector_new( size_t item_size )
 
     if( !self )
     {
-        fprintf( stderr,
-                 "line %d: No more memory for allocating data\n", __LINE__ );
-        exit( EXIT_FAILURE );
+        freetype_gl_error( Out_Of_Memory,
+			   "line %d: No more memory for allocating data\n", __LINE__ );
+	return NULL;
     }
     self->item_size = item_size;
     self->size      = 0;

--- a/vertex-attribute.c
+++ b/vertex-attribute.c
@@ -10,7 +10,7 @@
 #include "vec234.h"
 #include "platform.h"
 #include "vertex-attribute.h"
-
+#include "freetype-gl-err.h"
 
 
 // ----------------------------------------------------------------------------
@@ -67,7 +67,8 @@ vertex_attribute_parse( char *format )
         name = strndup(format, p-format);
         if( *(++p) == '\0' )
         {
-            fprintf( stderr, "No size specified for '%s' attribute\n", name );
+            freetype_gl_error( No_Size_Specified,
+			       "No size specified for '%s' attribute\n", name );
             free( name );
             return 0;
         }
@@ -75,7 +76,8 @@ vertex_attribute_parse( char *format )
 
         if( *(++p) == '\0' )
         {
-            fprintf( stderr, "No format specified for '%s' attribute\n", name );
+            freetype_gl_error( No_Format_Specified,
+			       "No format specified for '%s' attribute\n", name );
             free( name );
             return 0;
         }
@@ -92,7 +94,8 @@ vertex_attribute_parse( char *format )
     }
     else
     {
-        fprintf(stderr, "Vertex attribute format not understood ('%s')\n", format );
+        freetype_gl_error(Vertex_Attribute_Format_Wrong,
+			  "Vertex attribute format not understood ('%s')\n", format );
         return 0;
     }
 

--- a/vertex-buffer.c
+++ b/vertex-buffer.c
@@ -10,6 +10,7 @@
 #include "vec234.h"
 #include "platform.h"
 #include "vertex-buffer.h"
+#include "freetype-gl-err.h"
 
 /**
  * Buffer status


### PR DESCRIPTION
…lity with existing freetype-gl applications

Return values are still the same (NULL or 0 for errors). I've deleted the exit() calls, as a library never should exit on its own, even when the errors are fatal. Freetype errors are passed through. There's a hook for printing errors, so that the default behavior still is to print errors on stderr, but by changing the hook, applications can redirect the errors.