### PR TITLE
Fix loading of codepoints. 

### DIFF
--- a/texture-font.c
+++ b/texture-font.c
@@ -654,10 +654,9 @@ texture_font_load_glyphs( texture_font_t * self,
     size_t i, c;
 
     /* Load each glyph */
-    for( i = c = 0; c < utf8_strlen(codepoints); c++, i += utf8_surrogate_len(codepoints + i) ) {
+    for( i = 0; i < strlen(codepoints); i += utf8_surrogate_len(codepoints + i) ) {
         if( !texture_font_load_glyph( self, codepoints + i ) )
             return utf8_strlen( codepoints + i );
-
     }
 
     return 0;

--- a/texture-font.c
+++ b/texture-font.c
@@ -651,10 +651,10 @@ size_t
 texture_font_load_glyphs( texture_font_t * self,
                           const char * codepoints )
 {
-    size_t i;
+    size_t i, c;
 
     /* Load each glyph */
-    for( i = 0; i < utf8_strlen(codepoints); i += utf8_surrogate_len(codepoints + i) ) {
+    for( i = c = 0; c < utf8_strlen(codepoints); c++, i += utf8_surrogate_len(codepoints + i) ) {
         if( !texture_font_load_glyph( self, codepoints + i ) )
             return utf8_strlen( codepoints + i );
 


### PR DESCRIPTION
`texture_font_load_glyphs()` is incorrectly processing the passed in `codepoints` list.
It increments the index offset by each codepoint length correctly, but is using that *bytecount* as a *codepoint count*.

Thus it stops processing when it has read `utf8_strlen(codepoints)` bytes, not `utf8_strlen(codepoints)` glyphs. So if your codepoint list had 147 codepoints, only 147 bytes were being consumed.