### PR TITLE
Fixed Windows Harfbuzz build by adding platform.c to source files.

### DIFF
--- a/harfbuzz/CMakeLists.txt
+++ b/harfbuzz/CMakeLists.txt
@@ -21,6 +21,7 @@ set(FREETYPE_GL_HB_HDR
 )
 
 set(FREETYPE_GL_HB_SRC
+    platform.c
     texture-atlas.c
     texture-font.c
     vector.c

--- a/harfbuzz/platform.c
+++ b/harfbuzz/platform.c
@@ -1,0 +1,1 @@
+../platform.c


### PR DESCRIPTION
Fix to point 2 of #211; this solution was described in the issue as well.