### PR TITLE
docs: fix simple typo, minimimum -> minimum

### DIFF
--- a/distance-field.c
+++ b/distance-field.c
@@ -75,7 +75,7 @@ make_distance_mapb( unsigned char *img,
     unsigned char *out = (unsigned char *) malloc( width * height * sizeof(unsigned char) );
     unsigned int i;
 
-    // find minimimum and maximum values
+    // find minimum and maximum values
     double img_min = DBL_MAX;
     double img_max = DBL_MIN;
 


### PR DESCRIPTION
There is a small typo in distance-field.c.

Should read `minimum` rather than `minimimum`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md