### PR TITLE
Cmake Ninja backend support

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -59,7 +59,7 @@ add_custom_command(
         makefont
         ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt
     COMMAND
-        ../$<$<BOOL:MSVC>:$(Configuration)/>makefont
+        ../$<$<BOOL:MSVC>:${Configuration}/>makefont
     ARGS
         --font fonts/Vera.ttf
         --header ${CMAKE_CURRENT_SOURCE_DIR}/vera-16.h


### PR DESCRIPTION
$(Configuration)... to ${Configuration} for proper ninja backend support.

Currently ninja backend fails to build with following error message:
"ninja: error: build.ninja:1094: bad $-escape (literal $ must be written as $$)"