### PR TITLE
Provide means to change on error behaviour

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ set(FREETYPE_GL_HDR
     texture-atlas.h
     texture-font.h
     utf8-utils.h
+    ftgl-utils.h
     vec234.h
     vector.h
     vertex-attribute.h
@@ -136,6 +137,7 @@ set(FREETYPE_GL_SRC
     texture-atlas.c
     texture-font.c
     utf8-utils.c
+    ftgl-utils.c
     vector.c
     vertex-attribute.c
     vertex-buffer.c

--- a/font-manager.c
+++ b/font-manager.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "font-manager.h"
+#include "ftgl-utils.h"
 
 
 // ------------------------------------------------------------ file_exists ---
@@ -38,7 +39,7 @@ font_manager_new( size_t width, size_t height, size_t depth )
     self = (font_manager_t *) malloc( sizeof(font_manager_t) );
     if( !self )
     {
-        fprintf( stderr,
+        log_error(
                  "line %d: No more memory for allocating data\n", __LINE__ );
         exit( EXIT_FAILURE );
     }
@@ -124,7 +125,7 @@ font_manager_get_from_filename( font_manager_t *self,
         texture_font_load_glyphs( font, self->cache );
         return font;
     }
-    fprintf( stderr, "Unable to load \"%s\" (size=%.1f)\n", filename, size );
+    log_error( "Unable to load \"%s\" (size=%.1f)\n", filename, size );
     return 0;
 }
 
@@ -149,13 +150,13 @@ font_manager_get_from_description( font_manager_t *self,
     else
     {
 #if defined(_WIN32) || defined(_WIN64)
-        fprintf( stderr, "\"font_manager_get_from_description\" not implemented yet.\n" );
+        log_error( "\"font_manager_get_from_description\" not implemented yet.\n" );
         return 0;
 #endif
         filename = font_manager_match_description( self, family, size, bold, italic );
         if( !filename )
         {
-            fprintf( stderr, "No \"%s (size=%.1f, bold=%d, italic=%d)\" font available.\n",
+            log_error( "No \"%s (size=%.1f, bold=%d, italic=%d)\" font available.\n",
                      family, size, bold, italic );
             return 0;
         }
@@ -191,7 +192,7 @@ font_manager_match_description( font_manager_t * self,
     return 0;
 #else
 #  if defined _WIN32 || defined _WIN64
-      fprintf( stderr, "\"font_manager_match_description\" not implemented for windows.\n" );
+      log_error( "\"font_manager_match_description\" not implemented for windows.\n" );
       return 0;
 #  endif
     char *filename = 0;
@@ -219,7 +220,7 @@ font_manager_match_description( font_manager_t * self,
 
     if ( !match )
     {
-        fprintf( stderr, "fontconfig error: could not match family '%s'", family );
+        log_error( "fontconfig error: could not match family '%s'", family );
         return 0;
     }
     else
@@ -228,7 +229,7 @@ font_manager_match_description( font_manager_t * self,
         FcResult result = FcPatternGet( match, FC_FILE, 0, &value );
         if ( result )
         {
-            fprintf( stderr, "fontconfig error: could not match family '%s'", family );
+            log_error( "fontconfig error: could not match family '%s'", family );
         }
         else
         {

--- a/freetype-gl.h
+++ b/freetype-gl.h
@@ -8,6 +8,7 @@
 
 /* Mandatory */
 #include "opengl.h"
+#include "ftgl-utils.h"
 #include "vec234.h"
 #include "vector.h"
 #include "texture-atlas.h"

--- a/ftgl-utils.c
+++ b/ftgl-utils.c
@@ -1,0 +1,21 @@
+/* Freetype GL - A C OpenGL Freetype engine
+ *
+ * Distributed under the OSI-approved BSD 2-Clause License.  See accompanying
+ * file `LICENSE` for more details.
+ */
+#include "ftgl-utils.h"
+
+error_callback_t log_error = error_callback_default;
+void
+error_callback_default(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+}
+void
+ftgl_set_error_callback(error_callback_t error_callback)
+{
+    log_error = error_callback;
+}

--- a/ftgl-utils.c
+++ b/ftgl-utils.c
@@ -6,6 +6,8 @@
 #include "ftgl-utils.h"
 
 error_callback_t log_error = error_callback_default;
+
+// ------------------------------------------------- error_callback_default ---
 void
 error_callback_default(const char *fmt, ...)
 {
@@ -14,8 +16,10 @@ error_callback_default(const char *fmt, ...)
     vfprintf(stderr, fmt, args);
     va_end(args);
 }
+
+// ----------------------------------------------------- set_error_callback ---
 void
-ftgl_set_error_callback(error_callback_t error_callback)
+set_error_callback(error_callback_t error_cb)
 {
-    log_error = error_callback;
+    log_error = error_cb;
 }

--- a/ftgl-utils.h
+++ b/ftgl-utils.h
@@ -1,0 +1,41 @@
+/* Freetype GL - A C OpenGL Freetype engine
+ *
+ * Distributed under the OSI-approved BSD 2-Clause License.  See accompanying
+ * file `LICENSE` for more details.
+ */
+#ifndef __FTGL_UTILS_H__
+#define __FTGL_UTILS_H__
+#include <stdio.h>
+#include <stdarg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+namespace ftgl {
+#endif
+
+ /**
+  * This function sets
+  *
+  * @param atlas     A texture atlas
+  * @param pt_size   Size of font to be created (in points)
+  * @param filename  A font filename
+  *
+  * @return A new empty font (no glyph inside yet)
+  *
+  */
+typedef void (*error_callback_t) (const char *fmt, ...);
+extern error_callback_t log_error;
+void
+error_callback_default(const char *fmt, ...);
+void
+ftgl_set_error_callback(error_callback_t error_callback);
+
+#ifdef __cplusplus
+}
+}
+#endif
+
+#endif

--- a/ftgl-utils.h
+++ b/ftgl-utils.h
@@ -16,22 +16,28 @@ extern "C" {
 namespace ftgl {
 #endif
 
- /**
-  * This function sets
-  *
-  * @param atlas     A texture atlas
-  * @param pt_size   Size of font to be created (in points)
-  * @param filename  A font filename
-  *
-  * @return A new empty font (no glyph inside yet)
-  *
-  */
+
 typedef void (*error_callback_t) (const char *fmt, ...);
 extern error_callback_t log_error;
-void
-error_callback_default(const char *fmt, ...);
-void
-ftgl_set_error_callback(error_callback_t error_callback);
+
+/**
+ * Prints input to stderr
+ * This is fallback function for error reporting if ftgl_set_error_callback() wans't called
+ *
+ * @param fmt       cstring to be printed matching C-style printing syntax
+ * @param ...       va_list fmt supplying arguments
+ */
+  void
+  error_callback_default(const char *fmt, ...);
+
+/**
+ * Set function to call on error handling
+ * This is fallback function for error reporting if ftgl_set_error_callback() wans't called
+ *
+ * @param error_cb  callback function to call on error, see error_callback_default for reference
+ */
+  void
+  set_error_callback(error_callback_t error_cb);
 
 #ifdef __cplusplus
 }

--- a/text-buffer.c
+++ b/text-buffer.c
@@ -12,6 +12,7 @@
 #include "opengl.h"
 #include "text-buffer.h"
 #include "utf8-utils.h"
+#include "ftgl-utils.h"
 
 #define SET_GLYPH_VERTEX(value,x0,y0,z0,s0,t0,r,g,b,a,sh,gm) { \
     glyph_vertex_t *gv=&value;                                 \
@@ -191,7 +192,7 @@ text_buffer_add_text( text_buffer_t * self,
 
     if( !markup->font )
     {
-        fprintf( stderr, "Houston, we've got a problem !\n" );
+        log_error( "Houston, we've got a problem !\n" );
         return;
     }
 

--- a/texture-atlas.c
+++ b/texture-atlas.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <limits.h>
 #include "texture-atlas.h"
+#include "ftgl-utils.h"
 
 
 // ------------------------------------------------------ texture_atlas_new ---
@@ -26,7 +27,7 @@ texture_atlas_new( const size_t width,
     assert( (depth == 1) || (depth == 3) || (depth == 4) );
     if( self == NULL)
     {
-        fprintf( stderr,
+        log_error(
                  "line %d: No more memory for allocating data\n", __LINE__ );
         exit( EXIT_FAILURE );
     }
@@ -43,7 +44,7 @@ texture_atlas_new( const size_t width,
 
     if( self->data == NULL)
     {
-        fprintf( stderr,
+        log_error(
                  "line %d: No more memory for allocating data\n", __LINE__ );
         exit( EXIT_FAILURE );
     }
@@ -214,7 +215,7 @@ texture_atlas_get_region( texture_atlas_t * self,
     node = (ivec3 *) malloc( sizeof(ivec3) );
     if( node == NULL)
     {
-        fprintf( stderr,
+        log_error(
                  "line %d: No more memory for allocating data\n", __LINE__ );
         exit( EXIT_FAILURE );
     }

--- a/texture-font.c
+++ b/texture-font.c
@@ -17,6 +17,7 @@
 #include "texture-font.h"
 #include "platform.h"
 #include "utf8-utils.h"
+#include "ftgl-utils.h"
 
 #define HRES  64
 #define HRESf 64.f
@@ -36,28 +37,12 @@ static FT_F26Dot6 convert_float_to_F26Dot6(float value)
 #define FT_ERRORDEF( e, v, s )    case v: return s;
 #define FT_ERROR_END_LIST       }
 // Same signature as the function defined in fterrors.h:
-// https://www.freetype.org/freetype2/docs/reference/ft2-error_enumerations.html#ft_error_string
-const char* FT_Error_String( FT_Error error_code )
+// https://www.freetype.org/freetype2/docs/reference/ft2-error_enumerations.html#FTGL_Error_String
+const char* FTGL_Error_String( FT_Error error_code )
 {
 #include FT_ERRORS_H
     return "INVALID ERROR CODE";
 }
-
-error_callback_t log_error = error_callback_default;
-void
-error_callback_default(const char *fmt, ...)
-{
-    va_list args;
-    va_start(args, fmt);
-    vfprintf(stderr, fmt, args);
-    va_end(args);
-}
-void
-ftgl_set_error_callback(error_callback_t error_callback)
-{
-    log_error = error_callback;
-}
-
 
 // ------------------------------------------------- texture_font_load_face ---
 static int
@@ -78,8 +63,8 @@ texture_font_load_face(texture_font_t *self, float size,
     error = FT_Init_FreeType(library);
     if( error )
     {
-        fprintf( stderr, "FT_Error (line %d, 0x%02x) : %s\n",
-                 __LINE__, error, FT_Error_String(error) );
+        log_error( "FT_Error (line %d, 0x%02x) : %s\n",
+                 __LINE__, error, FTGL_Error_String(error) );
         goto cleanup;
     }
 
@@ -97,8 +82,8 @@ texture_font_load_face(texture_font_t *self, float size,
 
     if( error )
     {
-        fprintf( stderr, "FT_Error (line %d, code 0x%02x) : %s\n",
-                 __LINE__, error, FT_Error_String(error) );
+        log_error( "FT_Error (line %d, code 0x%02x) : %s\n",
+                 __LINE__, error, FTGL_Error_String(error) );
         goto cleanup_library;
     }
 
@@ -106,8 +91,8 @@ texture_font_load_face(texture_font_t *self, float size,
     error = FT_Select_Charmap(*face, FT_ENCODING_UNICODE);
     if( error )
     {
-        fprintf( stderr, "FT_Error (line %d, code 0x%02x) : %s\n",
-                 __LINE__, error, FT_Error_String(error) );
+        log_error( "FT_Error (line %d, code 0x%02x) : %s\n",
+                 __LINE__, error, FTGL_Error_String(error) );
         goto cleanup_face;
     }
 
@@ -127,8 +112,8 @@ texture_font_load_face(texture_font_t *self, float size,
 
     if( error )
     {
-        fprintf( stderr, "FT_Error (line %d, code 0x%02x) : %s\n",
-                 __LINE__, error, FT_Error_String(error) );
+        log_error( "FT_Error (line %d, code 0x%02x) : %s\n",
+                 __LINE__, error, FTGL_Error_String(error) );
         goto cleanup_face;
     }
 
@@ -151,7 +136,7 @@ texture_glyph_new(void)
 {
     texture_glyph_t *self = (texture_glyph_t *) malloc( sizeof(texture_glyph_t) );
     if(self == NULL) {
-        fprintf( stderr,
+        log_error(
                 "line %d: No more memory for allocating data\n", __LINE__);
         return NULL;
     }
@@ -319,7 +304,7 @@ texture_font_new_from_file(texture_atlas_t *atlas, const float pt_size,
 
     self = calloc(1, sizeof(*self));
     if (!self) {
-        fprintf(stderr,
+        log_error(
                 "line %d: No more memory for allocating data\n", __LINE__);
         return NULL;
     }
@@ -350,7 +335,7 @@ texture_font_new_from_memory(texture_atlas_t *atlas, float pt_size,
 
     self = calloc(1, sizeof(*self));
     if (!self) {
-        fprintf(stderr,
+        log_error(
                 "line %d: No more memory for allocating data\n", __LINE__);
         return NULL;
     }
@@ -463,7 +448,7 @@ texture_font_load_glyph( texture_font_t * self,
                                             -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
         if ( region.x < 0 )
         {
-            fprintf( stderr, "Texture atlas is full (line %d)\n",  __LINE__ );
+            log_error( "Texture atlas is full (line %d)\n",  __LINE__ );
             FT_Done_Face( face );
             FT_Done_FreeType( library );
             return 0;
@@ -532,8 +517,8 @@ texture_font_load_glyph( texture_font_t * self,
     error = FT_Load_Glyph( face, glyph_index, flags );
     if( error )
     {
-        fprintf( stderr, "FT_Error (line %d, code 0x%02x) : %s\n",
-                 __LINE__, error, FT_Error_String(error) );
+        log_error( "FT_Error (line %d, code 0x%02x) : %s\n",
+                 __LINE__, error, FTGL_Error_String(error) );
         FT_Done_Face( face );
         FT_Done_FreeType( library );
         return 0;
@@ -555,8 +540,8 @@ texture_font_load_glyph( texture_font_t * self,
 
         if( error )
         {
-            fprintf( stderr, "FT_Error (line %d, 0x%02x) : %s\n",
-                     __LINE__, error, FT_Error_String(error) );
+            log_error( "FT_Error (line %d, 0x%02x) : %s\n",
+                     __LINE__, error, FTGL_Error_String(error) );
             goto cleanup_stroker;
         }
 
@@ -570,8 +555,8 @@ texture_font_load_glyph( texture_font_t * self,
 
         if( error )
         {
-            fprintf( stderr, "FT_Error (line %d, 0x%02x) : %s\n",
-                     __LINE__, error, FT_Error_String(error) );
+            log_error( "FT_Error (line %d, 0x%02x) : %s\n",
+                     __LINE__, error, FTGL_Error_String(error) );
             goto cleanup_stroker;
         }
 
@@ -584,8 +569,8 @@ texture_font_load_glyph( texture_font_t * self,
 
         if( error )
         {
-            fprintf( stderr, "FT_Error (line %d, 0x%02x) : %s\n",
-                     __LINE__, error, FT_Error_String(error) );
+            log_error( "FT_Error (line %d, 0x%02x) : %s\n",
+                     __LINE__, error, FTGL_Error_String(error) );
             goto cleanup_stroker;
         }
 
@@ -596,8 +581,8 @@ texture_font_load_glyph( texture_font_t * self,
 
         if( error )
         {
-            fprintf( stderr, "FT_Error (line %d, 0x%02x) : %s\n",
-                     __LINE__, error, FT_Error_String(error) );
+            log_error( "FT_Error (line %d, 0x%02x) : %s\n",
+                     __LINE__, error, FTGL_Error_String(error) );
             goto cleanup_stroker;
         }
 
@@ -648,7 +633,7 @@ cleanup_stroker:
 
     if ( region.x < 0 )
     {
-        fprintf( stderr, "Texture atlas is full (line %d)\n",  __LINE__ );
+        log_error( "Texture atlas is full (line %d)\n",  __LINE__ );
         FT_Done_Face( face );
         FT_Done_FreeType( library );
         return 0;

--- a/texture-font.c
+++ b/texture-font.c
@@ -43,6 +43,22 @@ const char* FT_Error_String( FT_Error error_code )
     return "INVALID ERROR CODE";
 }
 
+error_callback_t log_error = error_callback_default;
+void
+error_callback_default(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+}
+void
+ftgl_set_error_callback(error_callback_t error_callback)
+{
+    log_error = error_callback;
+}
+
+
 // ------------------------------------------------- texture_font_load_face ---
 static int
 texture_font_load_face(texture_font_t *self, float size,

--- a/texture-font.h
+++ b/texture-font.h
@@ -329,21 +329,6 @@ typedef struct texture_font_t
 
 } texture_font_t;
 
-/**
- * This function sets 
- *
- * @param atlas     A texture atlas
- * @param pt_size   Size of font to be created (in points)
- * @param filename  A font filename
- *
- * @return A new empty font (no glyph inside yet)
- *
- */
- typedef void (*error_callback_t) (const char *fmt, ...);
- void error_callback_default(const char *fmt, ...);
- static error_callback_t log_error;
- void
- ftgl_set_error_callback(error_callback_t error_callback);
 
 
 /**

--- a/texture-font.h
+++ b/texture-font.h
@@ -329,6 +329,21 @@ typedef struct texture_font_t
 
 } texture_font_t;
 
+/**
+ * This function sets 
+ *
+ * @param atlas     A texture atlas
+ * @param pt_size   Size of font to be created (in points)
+ * @param filename  A font filename
+ *
+ * @return A new empty font (no glyph inside yet)
+ *
+ */
+ typedef void (*error_callback_t) (const char *fmt, ...);
+ void error_callback_default(const char *fmt, ...);
+ static error_callback_t log_error;
+ void
+ ftgl_set_error_callback(error_callback_t error_callback);
 
 
 /**

--- a/vector.c
+++ b/vector.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "vector.h"
+#include "ftgl-utils.h"
 
 
 
@@ -20,7 +21,7 @@ vector_new( size_t item_size )
 
     if( !self )
     {
-        fprintf( stderr,
+        log_error(
                  "line %d: No more memory for allocating data\n", __LINE__ );
         exit( EXIT_FAILURE );
     }

--- a/vertex-attribute.c
+++ b/vertex-attribute.c
@@ -10,6 +10,7 @@
 #include "vec234.h"
 #include "platform.h"
 #include "vertex-attribute.h"
+#include "ftgl-utils.h"
 
 
 
@@ -67,7 +68,7 @@ vertex_attribute_parse( char *format )
         name = strndup(format, p-format);
         if( *(++p) == '\0' )
         {
-            fprintf( stderr, "No size specified for '%s' attribute\n", name );
+            log_error( "No size specified for '%s' attribute\n", name );
             free( name );
             return 0;
         }
@@ -75,7 +76,7 @@ vertex_attribute_parse( char *format )
 
         if( *(++p) == '\0' )
         {
-            fprintf( stderr, "No format specified for '%s' attribute\n", name );
+            log_error( "No format specified for '%s' attribute\n", name );
             free( name );
             return 0;
         }
@@ -92,7 +93,7 @@ vertex_attribute_parse( char *format )
     }
     else
     {
-        fprintf(stderr, "Vertex attribute format not understood ('%s')\n", format );
+        log_error( "Vertex attribute format not understood ('%s')\n", format );
         return 0;
     }
 

--- a/vertex-buffer.c
+++ b/vertex-buffer.c
@@ -10,6 +10,7 @@
 #include "vec234.h"
 #include "platform.h"
 #include "vertex-buffer.h"
+#include "ftgl-utils.h"
 
 /**
  * Buffer status
@@ -195,7 +196,7 @@ vertex_buffer_print( vertex_buffer_t * self )
 
     assert(self);
 
-    fprintf( stderr, "%ld vertices, %ld indices\n",
+    log_error( "%ld vertices, %ld indices\n",
              vector_size( self->vertices ), vector_size( self->indices ) );
     while( self->attributes[i] )
     {
@@ -212,7 +213,7 @@ vertex_buffer_print( vertex_buffer_t * self )
         case GL_FLOAT:          j=7; break;
         default:                j=8; break;
         }
-        fprintf(stderr, "%s : %dx%s (+%p)\n",
+        log_error( "%s : %dx%s (+%p)\n",
                 self->attributes[i]->name,
                 self->attributes[i]->size,
                 gltypes[j],


### PR DESCRIPTION
Provide C-style callback function to call on error.

* default behaviour left unchanged (stream to `stderr`)
* expose logging output to end-user with `set_error_callback()`

Added this as `ftgl-utils` source files, since wasn't sure where else to place it, as there isn't any existing common header shared in codebase.

References rougier/freetype-gl#241