### PR TITLE
Emoji support

### DIFF
--- a/texture-font.c
+++ b/texture-font.c
@@ -667,6 +667,7 @@ cleanup_stroker:
 
     glyph = texture_glyph_new( );
     glyph->codepoint = utf8_to_utf32( codepoint );
+    glyph->is_placeholder = glyph_index == 0;
     glyph->width    = tgt_w;
     glyph->height   = tgt_h;
     glyph->rendermode = self->rendermode;

--- a/texture-font.c
+++ b/texture-font.c
@@ -109,6 +109,26 @@ texture_font_load_face(texture_font_t *self, float size,
      *  glyph as shown in Listing 1.”
      * That horizontal DPI factor is HRES here. */
     error = FT_Set_Char_Size(*face, convert_float_to_F26Dot6(size), 0, DPI * HRES, DPI);
+    
+    if( error && FT_HAS_FIXED_SIZES( *face ) )
+    {
+        // This font has fixed sizes; find the closest one and select that
+        float charsize = convert_float_to_F26Dot6(size);
+        float closest_y_ppem = 0;
+        float closest_x_ppem = 0;
+        float min_diff = INFINITY;
+        for( int i=0; i<(*face)->num_fixed_sizes; i++ )
+        {
+            float diff = (*face)->available_sizes[i].y_ppem - charsize;
+            if ( diff < min_diff ) {
+                min_diff = diff;
+                closest_y_ppem = (*face)->available_sizes[i].y_ppem;
+                closest_x_ppem = (*face)->available_sizes[i].x_ppem;
+            }
+        }
+        
+        error = FT_Set_Char_Size(*face, closest_y_ppem, closest_x_ppem, DPI, DPI);
+    }
 
     if( error )
     {

--- a/texture-font.h
+++ b/texture-font.h
@@ -193,6 +193,11 @@ typedef struct texture_glyph_t
      * Glyph outline thickness
      */
     float outline_thickness;
+    
+    /**
+     * Whether the glyph is a placeholder for a glyph that doesn't exist in the font
+     */
+    int is_placeholder;
 
 } texture_glyph_t;
 


### PR DESCRIPTION
Hi!

Three commits here which facilitate display of emojis. 

The first adds an "is_placeholder" field of texture_glyph_t which indicates when a glyph is missing from a font (and is thus a placeholder), which can be used for swapping the missing glyph out for one from an emoji font.

The second adds a workaround for fixed-size fonts (like emoji fonts), which due to some shenanigans within FreeType will fail to load unless the size matches exactly. The workaround finds the closest size and uses that instead.

The third commit adds support for RGBA texture atlases, adding a facility to convert from single-channel greyscale bitmaps to an RGBA texture atlas (for regular text), and to convert from the BGRA channel layout used in full-colour fonts to the RGBA format used in the texture atlas, among other things.