### PR TITLE
Update CMakeLists.txt to use targets more correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ Makefile
 libfreetype-gl.a
 makefont
 /build
+/.vs
+/out
+/glfw-3.2.1*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,6 @@ if((${CMAKE_SYSTEM_NAME} MATCHES "Darwin") OR
     set(freetype-gl_WITH_GLEW_DEFAULT OFF)
 endif()
 
-option(freetype-gl_DEBUG
-    "Use the DEBUG option to build for debugging"
-    OFF)
 option(freetype-gl_WITH_GLEW
     "Use the GLEW library to fetch OpenGL function pointers"
     ${freetype-gl_WITH_GLEW_DEFAULT})
@@ -246,8 +243,3 @@ install(TARGETS freetype-gl
 install(FILES ${FREETYPE_GL_HDR} DESTINATION include
 	COMPONENT headers)
 
-if(freetype-gl_DEBUG)
-    set(CMAKE_BUILD_TYPE Debug)
-else()
-    set(CMAKE_BUILD_TYPE Release)
-endif()

--- a/ftgl-utils.h
+++ b/ftgl-utils.h
@@ -20,9 +20,6 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifdef __cplusplus
 namespace ftgl {
 #endif
 
@@ -139,7 +136,7 @@ extern
 #endif
 "C" {
 #  endif
-    
+
 # endif /* !FTGL_ERRORDEF */
 
     /* this macro is used to define an error */
@@ -155,6 +152,7 @@ extern
 #undef FTGL_ERROR_END_LIST
 
 #ifdef __cplusplus
+}
 }
 }
 #endif

--- a/ftgl-utils.h
+++ b/ftgl-utils.h
@@ -129,14 +129,6 @@ const char* freetype_gl_errstrs[];
 #  define FTGL_ERROR_START_LIST     enum {
 #  define FTGL_ERROR_END_LIST       FTGL_ERR_CAT( FTGL_ERR_PREFIX, Max ) };
 
-#  ifdef __cplusplus
-#   define FTGL_NEED_EXTERN_C
-#ifndef IMPLEMENT_FREETYPE_GL
-extern
-#endif
-"C" {
-#  endif
-
 # endif /* !FTGL_ERRORDEF */
 
     /* this macro is used to define an error */
@@ -152,7 +144,6 @@ extern
 #undef FTGL_ERROR_END_LIST
 
 #ifdef __cplusplus
-}
 }
 }
 #endif


### PR DESCRIPTION
After #169 was merged in some issues raise up in the projects I'm working on. So I had to do some fixes

~~- move libraries from global scope to freetype-gl target for dependency use~~
~~- silence warnings of cmake policy due support for older cmake~~
~~- remove debug build flag, invoker should provide that flag global~~
~~- move defines to freetype-gl target from global list~~
~~- fix missing bracket in ftgl-utils header~~

Ended up reverting the changes I did to the cmake as tests failed. I cannot run tests on my side as the default build doesn't link so it's hard to debug where the issue is. For now it would be great if atleast this could get merged in order to make things compile again.