### PR TITLE
Duplicated non-closed C scope removed

### DIFF
--- a/ftgl-utils.h
+++ b/ftgl-utils.h
@@ -134,10 +134,6 @@ const char* freetype_gl_errstrs[];
 
 #  ifdef __cplusplus
 #   define FTGL_NEED_EXTERN_C
-#ifndef IMPLEMENT_FREETYPE_GL
-extern
-#endif
-"C" {
 #  endif
     
 # endif /* !FTGL_ERRORDEF */


### PR DESCRIPTION
`ftgl-utils.h` contained duplicated non-closed `extern "C" {` scope, which caused the failure of C++ builds linking that header:
```sh
...
/usr/include/eigen3/Eigen/src/Core/GlobalFunctions.h:45:3: note: in definition of macro ‘EIGEN_ARRAY_DECLARE_GLOBAL_EIGEN_UNARY’
   45 |   template<typename Derived> \
      |   ^~~~~~~~
In file included from ${PROJECT}/build/_deps/freetype-gl-src/freetype-gl.h:16,
                 from ${PROJECT}/src/ui/GLFont.hpp:3,
                 from ${PROJECT}/src/ui/GLFont.cpp:1:
${PROJECT}/build/_deps/freetype-gl-src/ftgl-utils.h:22:1: note: ‘extern "C"’ linkage started here
   22 | extern "C" {
      | ^~~~~~~~~~
In file included from ${PROJECT}/src/ui/GLFont.cpp:1:
${PROJECT}/src/ui/GLFont.hpp:34:2: error: template with C linkage
   34 |  template <typename Iter>
      |  ^~~~~~~~
In file included from ${PROJECT}/build/_deps/freetype-gl-src/freetype-gl.h:16,
                 from ${PROJECT}/src/ui/GLFont.hpp:3,
                 from ${PROJECT}/src/ui/GLFont.cpp:1:
${PROJECT}/build/_deps/freetype-gl-src/ftgl-utils.h:22:1: note: ‘extern "C"’ linkage started here
   22 | extern "C" {
      | ^~~~~~~~~~
${PROJECT}/src/ui/GLFont.cpp:148:1: error: expected ‘}’ at end of input
  148 | } // namespace artemis
      | ^
In file included from ${PROJECT}/build/_deps/freetype-gl-src/freetype-gl.h:16,
                 from ${PROJECT}/src/ui/GLFont.hpp:3,
                 from ${PROJECT}/src/ui/GLFont.cpp:1:
${PROJECT}/build/_deps/freetype-gl-src/ftgl-utils.h:22:12: note: to match this ‘{’
   22 | extern "C" {
      |            ^
make[2]: *** [src/CMakeFiles/artemis-common.dir/build.make:370: src/CMakeFiles/artemis-common.dir/ui/GLUserInterface.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [src/CMakeFiles/artemis-common.dir/build.make:422: src/CMakeFiles/artemis-common.dir/ui/GLFont.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:795: src/CMakeFiles/artemis-common.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```