### PR TITLE
remove redundant rendermode_t def from texture-font.h

### DIFF
--- a/harfbuzz/texture-font.h
+++ b/harfbuzz/texture-font.h
@@ -58,19 +58,6 @@ typedef enum rendermode_t
     RENDER_SIGNED_DISTANCE_FIELD
 } rendermode_t;
 
-
-/**
- * A list of possible ways to render a glyph.
- */
-typedef enum rendermode_t
-{
-    RENDER_NORMAL,
-    RENDER_OUTLINE_EDGE,
-    RENDER_OUTLINE_POSITIVE,
-    RENDER_OUTLINE_NEGATIVE,
-    RENDER_SIGNED_DISTANCE_FIELD
-} rendermode_t;
-
 /**
  * A structure that describe a glyph.
  */


### PR DESCRIPTION
This is a quick bugfix to remove a redundant `rendermode_t` definition from `texture-font.h`