### PR TITLE
Fix double deletion of glyph kerning vector

### DIFF
--- a/texture-font.h
+++ b/texture-font.h
@@ -686,6 +686,14 @@ texture_glyph_new( void );
 void
 texture_glyph_delete( texture_glyph_t * self );
 
+/**
+ * Clone a glyph
+ *
+ * @param self         A valid texture glyph
+ */
+texture_glyph_t*
+texture_glyph_clone( texture_glyph_t* self );
+
 /** @} */
 
 #define GLYPHS_ITERATOR1(index, name, glyph) \


### PR DESCRIPTION
Hello,

Here is a ready to merge pull request that fixes a double deletion crash!

I had a crash inside texture_glyph_delete () when iterating over `for(i=0; i < self->kerning->size; i++)` because the `self->kerning` vector was already freed.

The issue was that the `vector_t* kerning` was duplicated via a simple `memcpy()` in `texture_font_load_glyph_gi()`, instead of making a real copy of the vector.

This pull request introduces a new function `texture_glyph_clone()` that performs a deep copy of the glyph, _i.e._ it explicitly clones the kerning vector.

Note that this is still imperfect, because there is another location where glyphs are duplicated with `memcpy()`, which is inside 
`texture_font_index_glyph()`. I must admit, I'm not totally confident with the `texture_glyph_t ***` triple pointer which is there, but if you wish I can try to do a full fix. Probably, this requires to modify the current glyph "clone" function by a "copy in place" function.
