### PR TITLE
add support for off-screen render at linux without glx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(freetype-gl_BUILD_HARFBUZZ "Build the freetype-gl harfbuzz support (exper
 option(freetype-gl_BUILD_MAKEFONT "Build the makefont tool" ON)
 option(freetype-gl_BUILD_TESTS "Build the tests" ON)
 option(freetype-gl_BUILD_SHARED "Build shared library" OFF)
+option(freetype-gl_OFF_SCREEN "Build for off-screen render (build libfreetype-gl.so only without GLX, demos must disable because of missing glfw)" OFF)
 
 include(RequireIncludeFile)
 include(RequireFunctionExists)
@@ -91,7 +92,17 @@ if(NOT MINGW AND (WIN32 OR WIN64))
         ${CMAKE_CURRENT_SOURCE_DIR}/windows/freetype)
 endif()
 
-find_package(OpenGL REQUIRED)
+if(freetype-gl_OFF_SCREEN)
+    set(freetype-gl_BUILD_DEMOS OFF)
+
+    # Build OFF screen must use FindOpenGL with GLVND
+    # The only one module OpenGL are needed for libOpenGL.so
+    set(OpenGL_GL_PREFERENCE GLVND)
+    find_package(OpenGL REQUIRED OpenGL EGL)
+    set(OPENGL_LIBRARY ${OPENGL_opengl_LIBRARY})
+else()
+    find_package(OpenGL REQUIRED)
+endif()
 find_package(Freetype REQUIRED)
 
 if(freetype-gl_WITH_GLEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ endif()
 find_package(Freetype REQUIRED)
 
 if(freetype-gl_WITH_GLEW)
+    add_definitions(-DWITH_GLEW=1)
     find_package(GLEW REQUIRED)
 endif()
 

--- a/opengl.h
+++ b/opengl.h
@@ -30,7 +30,9 @@
 #    include <GLES2/gl2.h>
 #  endif
 #else
+#if defined(WITH_GLEW)
 #  include <GL/glew.h>
+#endif
 #  include <GL/gl.h>
 #endif
 #endif /* GL_WITH_GLAD */


### PR DESCRIPTION
also add predefine macro to prevent include glew.h while build without GLEW

build pass with command
```
cmake .. -Dfreetype-gl_BUILD_DEMOS=OFF -Dfreetype-gl_BUILD_TESTS=OFF -Dfreetype-gl_OFF_SCREEN=ON -Dfreetype-gl_BUILD_SHARED=ON -Dfreetype-gl_WITH_GLEW=OFF
make
```
