### PR TITLE
makefont: Fix invalid C data structures declarations

### DIFF
--- a/demos/embedded-font.c
+++ b/demos/embedded-font.c
@@ -26,7 +26,7 @@ void print_at( int pen_x, int pen_y, char *text )
     for( i=0; i < strlen(text); ++i) {
 	texture_glyph_t *glyph = 0;
 	codepoint = utf8_to_utf32( text + i );
-	glyph = font.glyphs[codepoint>>8].glyphs[codepoint&0xff];
+	glyph = font.glyphs[codepoint>>8][codepoint&0xff];
         if( !glyph )
         {
             continue;

--- a/makefont.c
+++ b/makefont.c
@@ -39,7 +39,7 @@ void print_glyph(FILE * file, texture_glyph_t * glyph)
     fprintf( file, "%ff, %ff, %ff, %ff, ", glyph->s0, glyph->t0, glyph->s1, glyph->t1 );
     fprintf( file, "%" PRIzu ", ", vector_size(glyph->kerning) );
     if (vector_size(glyph->kerning) == 0) {
-	fprintf( file, "0" );
+	fprintf( file, "{{0}}" );
     } else {
 	int k;
 	fprintf( file, "{ " );
@@ -432,12 +432,6 @@ int main( int argc, char **argv )
         "} texture_glyph_t;\n\n", max_kerning_count );
 
     fprintf( file,
-	     "typedef struct\n"
-	     "{\n"
-	     "   texture_glyph_t *glyphs[0x100];\n"
-	     "} texture_glyph_0x100_t;\n\n" );
-
-    fprintf( file,
         "typedef struct\n"
         "{\n"
         "    size_t tex_width;\n"
@@ -450,7 +444,7 @@ int main( int argc, char **argv )
         "    float ascender;\n"
         "    float descender;\n"
         "    size_t glyphs_count;\n"
-        "    texture_glyph_0x100_t glyphs[%" PRIzu "];\n"
+        "    texture_glyph_t *glyphs[%" PRIzu "][0x100];\n"
         "} texture_font_t;\n\n", texture_size, glyph_count );
 
     texture_glyph_t * glyph;


### PR DESCRIPTION
The data structures generated by makefont are not valid, and may fail
to compile depending on compiler flags:

  error: missing braces around initializer [-Werror=missing-braces]
  | texture_glyph_t font_glyph_00000020 =   {32, 2, 2, 0, 0, 9.640625f
  |                                         ^

The texture_glyph_t::kerning field is a double array, so it is invalid
to initialize it as an integer, "0". When a glyph has no kerning
pairs, initialize the "kerning" field to "{{0}}".

Remove the "texture_glyph_0x100_t" structure and incorporate the
glyphs pointer array directly into texture_font_t.