### PR TITLE
Added missing 'void' in text_buffer_new function

### DIFF
--- a/text-buffer.c
+++ b/text-buffer.c
@@ -24,7 +24,7 @@
 // ----------------------------------------------------------------------------
 
 text_buffer_t *
-text_buffer_new( )
+text_buffer_new( void )
 {
     text_buffer_t *self = (text_buffer_t *) malloc (sizeof(text_buffer_t));
     self->buffer = vertex_buffer_new(

--- a/text-buffer.h
+++ b/text-buffer.h
@@ -212,7 +212,7 @@ typedef enum Align
  *
  */
   text_buffer_t *
-  text_buffer_new( );
+  text_buffer_new( void );
 
 /**
  * Deletes texture buffer and its associated vertex buffer.


### PR DESCRIPTION
Currently compiling simple main.c which includes text-buffer.h using clang with -Werror and -Wstrict-prototypes results in error with the following message:

```
error: a function declaration without a prototype is deprecated in all versions of C
```

Putting a simple void fixes the problem.