### PR TITLE
Extended meson.build for demo/markup on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,6 @@ makefont
 
 /subprojects/*
 !/subprojects/*.wrap
+!/subprojects/packagefiles
 /builddir
 /prefix

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ makefont
 /.vs
 /out
 /glfw-3.2.1*
+
+/subprojects/*
+!/subprojects/*.wrap
+/builddir
+/prefix

--- a/demos/markup.c
+++ b/demos/markup.c
@@ -46,13 +46,6 @@ GLuint text_shader;
 char *
 match_description( char * description )
 {
-
-#if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
-    fprintf( stderr, "\"font_manager_match_description\" "
-                     "not implemented for windows.\n" );
-    return 0;
-#endif
-
     char *filename = 0;
     FcInit();
     FcPattern *pattern = FcNameParse(description);

--- a/demos/meson.build
+++ b/demos/meson.build
@@ -1,0 +1,15 @@
+files = files(
+'mat4.h',
+'mat4.c',
+'screenshot-util.h',
+'screenshot-util.c',
+'shader.h',
+'shader.c',
+)
+
+glfw3_dep = dependency('glfw3', default_options: ['install=true'])
+fontconfig_dep = dependency('fontconfig')
+
+executable('markup', files + ['markup.c'],
+dependencies: [freetype_gl_dep, glfw3_dep, fontconfig_dep],
+install: true)

--- a/meson.build
+++ b/meson.build
@@ -34,3 +34,5 @@ freetype_gl_dep = declare_dependency(include_directories: inc, dependencies: dep
 
 makefont_sources = files('makefont.c')
 executable('makefont', makefont_sources, dependencies: freetype_gl_dep, install: true)
+
+subdir('demos')

--- a/meson.build
+++ b/meson.build
@@ -1,9 +1,9 @@
 project('freetype-gl', 'c')
 
 c = meson.get_compiler('c')
-m = c.find_library('m')
 freetype2 = dependency('freetype2')
 gl = dependency('opengl')
+glew = dependency('glew')
 
 conf_data = configuration_data()
 configure_file(output: 'config.h', configuration: conf_data)
@@ -23,10 +23,14 @@ freetype_gl_sources = files('distance-field.c',
                 'vertex-buffer.c')
 
 inc = include_directories('.')
-deps = [freetype2, gl, m]
+deps = [freetype2, gl, glew]
+if host_machine.system() != 'windows'
+    m = c.find_library('m')
+    deps += m
+endif
 
-freetype_gl_lib = library('freetype-gl', freetype_gl_sources, include_directories: inc, dependencies: deps)
+freetype_gl_lib = static_library('freetype-gl', freetype_gl_sources, include_directories: inc, dependencies: deps)
 freetype_gl_dep = declare_dependency(include_directories: inc, dependencies: deps, link_with: freetype_gl_lib)
 
 makefont_sources = files('makefont.c')
-executable('makefont', makefont_sources, dependencies: freetype_gl_dep)
+executable('makefont', makefont_sources, dependencies: freetype_gl_dep, install: true)

--- a/subprojects/fontconfig.wrap
+++ b/subprojects/fontconfig.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+source_url = https://gitlab.freedesktop.org/fontconfig/fontconfig/-/archive/2.14.1/fontconfig-2.14.1.tar.bz2
+source_filename = fontconfig-2.14.1.tar.bz2
+source_hash = 78c7ffcfb7f950ad4e0b5ad38040e032517140d23e6520314d3b591527a0f9fe
+directory = fontconfig-2.14.1
+diff_files = fontconfig/meson.build.patch
+
+[provide]
+fontconfig = fontconfig_dep

--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = freetype-2.12.1
+source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.12.1.tar.xz
+source_filename = freetype-2.12.1.tar.xz
+source_hash = 4766f20157cc4cf0cd292f80bf917f92d1c439b243ac3018debf6b9140c41a7f
+wrapdb_version = 2.12.1-2
+
+[provide]
+freetype2 = freetype_dep
+freetype = freetype_dep

--- a/subprojects/glew.wrap
+++ b/subprojects/glew.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = glew-2.2.0
+source_url = http://downloads.sourceforge.net/glew/glew-2.2.0.tgz
+source_filename = glew-2.2.0.tgz
+source_hash = d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1
+patch_filename = glew_2.2.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/glew_2.2.0-2/get_patch
+patch_hash = df7bc80456da53f83e93e89ca5035d04cdff19a836c956887a684b2bee16eb9b
+wrapdb_version = 2.2.0-2
+
+[provide]
+glew = glew_dep

--- a/subprojects/glfw.wrap
+++ b/subprojects/glfw.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = glfw-3.3.8
+source_url = https://github.com/glfw/glfw/archive/refs/tags/3.3.8.tar.gz
+source_filename = glfw-3.3.8.tar.gz
+source_hash = f30f42e05f11e5fc62483e513b0488d5bceeab7d9c5da0ffe2252ad81816c713
+patch_filename = glfw_3.3.8-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/glfw_3.3.8-2/get_patch
+patch_hash = eca865a15ff49d29d1a710fda3cfb9ca82057dda7f15ed617a1677cc5992c503
+wrapdb_version = 3.3.8-2
+
+[provide]
+glfw3 = glfw_dep

--- a/subprojects/packagefiles/fontconfig/meson.build.patch
+++ b/subprojects/packagefiles/fontconfig/meson.build.patch
@@ -1,0 +1,11 @@
+--- .\meson.build.orig	Fri Oct 21 14:14:03 2022
++++ .\meson.build	Thu Dec 29 18:09:40 2022
+@@ -320,7 +320,7 @@ gperf = find_program('gperf')
+ 
+ sh = find_program('sh', required : false)
+ 
+-if not sh.found() # host_machine.system() == 'windows' or not sh.found()
++if host_machine.system() == 'windows' or not sh.found()
+   # TODO: This is not always correct
+   if cc.get_id() == 'msvc'
+     gperf_len_type = 'size_t'

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = zlib-1.2.13
+source_url = http://zlib.net/fossils/zlib-1.2.13.tar.gz
+source_filename = zlib-1.2.13.tar.gz
+source_hash = b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
+patch_filename = zlib_1.2.13-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/zlib_1.2.13-2/get_patch
+patch_hash = a7abea3ad65dc2c291ad5fbbf5355d0585a7f7b8c935d4a74335b8fe18684506
+wrapdb_version = 1.2.13-2
+
+[provide]
+zlib = zlib_dep


### PR DESCRIPTION
I Extended meson.build for demo/markup on windows.
Remove return in `match_description`  if windows.
Because fontconfig worked on windows too.

This screenshot was made with a `markup --screenshot ss.tga` build on Windows11.

![markup](https://user-images.githubusercontent.com/68057/209945166-6b67e372-126e-4aa2-ac1c-6c73dfc53765.png)

`Droid fonts` and `DroidSansJapanese.ttf` is required undere `%APPLOCAL%\Microsoft\Windows\Fonts` folder.

Thank you.

