### PR TITLE
Add AUR link in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,9 @@
 # Install
 
+## Arch Linux
+
+freetype-gl is available on the [Arch User Repository](https://aur.archlinux.org/packages/freetype-gl).
+
 ## Ubuntu
 
 The procedure is detailed in the [.travis.yml](.travis.yml).


### PR DESCRIPTION
Hi, freetype-gl can be installed on Arch Linux with the PKGBUILD on the Arch User Repository.