### PR TITLE
Define GL_GLEXT_PROTOTYPES to get prototypes for GL extensions

### DIFF
--- a/opengl.h
+++ b/opengl.h
@@ -34,6 +34,7 @@
 #if defined(FREETYPE_GL_USE_GLEW)
 #  include <GL/glew.h>
 #endif
+#  define GL_GLEXT_PROTOTYPES
 #  include <GL/gl.h>
 #endif
 #endif /* GL_WITH_GLAD */


### PR DESCRIPTION
Freetype-gl uses several functions that are only declared on Linux if GL_GLEXT_PROTOTYPES is defined.

Define GL_GLEXT_PROTOTYPES, to get prototypes for functions like glGetAttribLocation. Since C99, prototypes are needed for all functions, and e.g. clang-18 will warn if the prototypes are not available.