### PR TITLE
Fix undefined behavior in utf8_surrogate_len

### DIFF
--- a/utf8-utils.c
+++ b/utf8-utils.c
@@ -11,7 +11,7 @@ size_t
 utf8_surrogate_len( const char* character )
 {
     size_t result = 0;
-    char test_char;
+    unsigned char test_char;
 
     if (!character)
         return 0;


### PR DESCRIPTION
`char` may be signed. Left shift of negative values is undefined behavior. Use an `unsigned char` for calculating the utf8 surrogate length.